### PR TITLE
changed the referer to be an object for easier expansion

### DIFF
--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -84,7 +84,8 @@
    * Method that converts a module name to a path to the module file.
    *
    * @param {string} name - Name of the module to generate a path for
-   * @param {string} referer - Location of the requesting module.
+   * @param {{path: string, name: string}} referer - Object with the
+   *  location and name of the requesting module.
    *
    * @returns {Promise} Promise that when resolved, will return an object with
    *  a required field `path` where we can load the module file from.
@@ -98,7 +99,8 @@
    *
    * @param {string} name - Name of the module whose file content needs to be
    *  fetched.
-   * @param {string} referer - Location of the requesting module.
+   * @param {{path: string, name: string}} referer - Object with the
+   *  location and name of the requesting module.
    *
    * @returns {Promise} Promise that when resolved, a module meta object
    *  with a "source" property is returned. The "source" property is where

--- a/src/loader.js
+++ b/src/loader.js
@@ -89,7 +89,8 @@
    * link module
    *
    * @param {string} name - The name of the module to load.
-   * @param {string} referer - Location of the requesting module.
+   * @param {{path: string, name: string}} referer - Object with the
+   *  location and name of the requesting module.
    *
    * @returns {Promise} - Promise that will resolve to a Module instance
    */
@@ -130,7 +131,8 @@
    * module meta objects to instances of Module.
    *
    * @param {string} name - The name of the module to fetch.
-   * @param {string} referer - Location of the requesting module.
+   * @param {{path: string, name: string}} referer - Object with the
+   *  location and name of the requesting module.
    *
    * @returns {Promise}
    */

--- a/src/meta/dependency.js
+++ b/src/meta/dependency.js
@@ -43,7 +43,7 @@
     var i, length, loading = new Array(moduleMeta.deps.length);
 
     for (i = 0, length = moduleMeta.deps.length; i < length; i++) {
-      loading[i] = manager.providers.loader.fetch(moduleMeta.deps[i], moduleMeta.path);
+      loading[i] = manager.providers.loader.fetch(moduleMeta.deps[i], moduleMeta);
     }
 
     function dependenciesFetched() {


### PR DESCRIPTION
the only thing that the referee can guarantee to have the path and name
of the requesting module