### PR TITLE
Rule matcher refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,15 +163,15 @@ You can take a look at [this](https://gist.github.com/MiguelCastillo/37944827c0c
 
 bit loader is a *JavaScript module loader* first, and plugins are a way to augment the types of modules that can be loaded and consumed by the host application.  So, while bit loader provides you with a very flexible plugin system for processing modules, there is a layer of core function hooks that are the default handlers when plugins can't process a particular module.
 
-- **resolve** - function that converts module names (ids) to paths. Paths are used plugins and the `fetch` hook to load module files.
-- **fetch** - function that loads module files from storage. These files are processed by plugins and the `compile` hook to build modules.
-- **compile** - function that evaluates module files with `eval`, or some other equivalent mechanism to create code that can be consumed by the host application.
+- **resolve** - *function* that converts module names (ids) to paths. Paths are used by `fetch` plugins and core hooks to load module files.
+- **fetch** - *function* that loads module files from storage. These files are processed by `compile` plugins and core hooks to build modules.
+- **compile** - *function* that evaluates module files with `eval`, or other equivalent mechanism to create code that can be consumed by the host application.
 
-So, plugins and their core function hook counterparts have fundamentally the same responsibilities. However, the one function hook that has real implications is `compile`; they primarly differ in when and how they run.
+So, plugins and their core function hook counterparts have fundamentally the same responsibilities. However, the one function hook that has real implications is `compile`; `compile` core hook and plugins primarly differ in when and how they run.
 
-All plugins run in the first stage, which is *asynchronous* and runs before the build stage. This means that `compile` plugins are *asynchronous* and run before the `compile` handler in the build stage. Furthermore, there can only be one `compile` handler in the build stage, and its intended use case is for *synchronously* building JavaScript modules when the host application requires them.  Think `CJS`... All other function hooks run *asynchronously* when there are no plugins that can process a module.
+All plugins run in the first stage, which is *asynchronous* and runs before the build stage. This means that `compile` plugins are *asynchronous* and run before the `compile` core hook in the build stage, which is *synchronous*.
 
-Checkout [bit imports](https://github.com/MiguelCastillo/bit-imports) for an implementation of these core function hooks.
+> [bit imports](https://github.com/MiguelCastillo/bit-imports) implements these core hooks to provide a base layer for processing JavaScript modules.
 
 #### Core hooks example
 ``` javascript
@@ -198,7 +198,7 @@ function compileModule(moduleMeta) {
 
 
 //
-// Instantiate bitloader
+// Instantiate bitloader providing core hooks.
 //
 var bitloader = new Bitloader({
   resolve : resolvePath,
@@ -213,8 +213,7 @@ So what exactly are the pipelines and core hooks processing around, anyways? The
 
 > Modifying module meta objects is the primary responsibility of the different pipelines and core hooks.
 
-- **load** - creates module meta objects with the name of the module being loaded
-- **resolve** - uses the module meta `name` from `load` to create and set the module meta `path`.
+- **resolve** - uses the module meta `name` to create and set the module meta `path`.
 - **fetch** - loads the module file using the `path` from `resolve`, and sets the module meta `source`.
 - **transform** - processes the module `source` from `fetch`, and sets the module meta `source`.
 - **dependency** - processes the module `source` from `fetch`, and sets the module meta `deps`.

--- a/README.md
+++ b/README.md
@@ -124,19 +124,20 @@ bitloader.plugin("css", {
 });
 ```
 
-You can configure matching rules in a plugin to specify which module files it can process. Below is an example configuring the `css` plugin to only process files with `.css` and `.less` extensions:
+You can configure matching rules in a plugin to specify which module files the plugin can process. Below is an example configuring the `css` plugin to only process files with `.css` and `.less` extensions:
 
 ``` javascript
 var bitloader = new Bitloader();
+var extension = Bitloader.Rule.matcher.extension;
 
 bitloader.plugin("css", {
   match: {
-    path: ["**/*.css", "**/*.less"]
+    path: extension("css|less")
   }
 });
 ```
 
-> Matching rules are globs.
+> There are several built in matching rules.  One for file extensions, one for string matching, another for regex, and one for generic strict equality comparison.
 
 So, it is valid to register other handlers into a previously registered plugin using the plugin name, which is the primary reason plugins have names in the first place. But the more common use case is to configure plugins in a single call:
 
@@ -144,10 +145,11 @@ So, it is valid to register other handlers into a previously registered plugin u
 
 ``` javascript
 var bitloader = new Bitloader();
+var extension = Bitloader.Rule.matcher.extension;
 
 bitloader.plugin("css", {
   match: {
-    path: ["**/*.css", "**/*.less"]
+    path: extension("css|less")
   },
   fetch: fetchCss,
   transform: [cssTransform1, cssTransform2]

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "grunt-release": "~0.12.0",
     "jshint-stylish": "~1.0.2",
     "mocha": "~2.2.4",
-    "sinon": "~1.14.1"
+    "sinon": "~1.14.1",
+    "minimatch": "MiguelCastillo/minimatch"
   },
   "dependencies": {
-    "minimatch": "^2.0.7",
     "spromise": "~0.9.3"
   },
   "browser": {

--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -1,16 +1,16 @@
-var Logger      = require("./logger");
-var Promise     = require("./promise");
-var Utils       = require("./utils");
-var Fetcher     = require("./interfaces/fetcher");
-var Compiler    = require("./interfaces/compiler");
-var Resolver    = require("./interfaces/resolver");
-var Import      = require("./import");
-var Loader      = require("./loader");
-var Module      = require("./module");
-var Plugin      = require("./plugin");
-var Registry    = require("./registry");
-var RuleMatcher = require("./rule-matcher");
-var Middleware  = require("./middleware");
+var Logger     = require("./logger");
+var Promise    = require("./promise");
+var Utils      = require("./utils");
+var Fetcher    = require("./interfaces/fetcher");
+var Compiler   = require("./interfaces/compiler");
+var Resolver   = require("./interfaces/resolver");
+var Import     = require("./import");
+var Loader     = require("./loader");
+var Module     = require("./module");
+var Plugin     = require("./plugin");
+var Registry   = require("./registry");
+var Rule       = require("./rule-matcher");
+var Middleware = require("./middleware");
 
 var getRegistryId = Registry.idGenerator("bitloader");
 
@@ -28,7 +28,12 @@ function Bitloader(options) {
   this.plugins  = {};
 
   this.rules = {
-    ignore: new RuleMatcher()
+    ignore: {
+      fetch: new Rule(),
+      transform: new Rule(),
+      dependency: new Rule(),
+      compile: new Rule()
+    }
   };
 
   this.pipelines = {
@@ -299,7 +304,7 @@ Bitloader.prototype.ignore = function(rule) {
   }
   else {
     if (rule.name === "*") {
-      ruleNames = Object.keys(this.pipelines);
+      ruleNames = Object.keys(this.rules.ignore);
     }
     else {
       ruleNames = Utils.isArray(rule.name) ? rule.name : [rule.name];
@@ -307,10 +312,7 @@ Bitloader.prototype.ignore = function(rule) {
   }
 
   for (i = 0, length = ruleNames.length; i < length; i++) {
-    this.rules.ignore.add({
-      name: ruleNames[i],
-      match: rule.match
-    });
+    this.rules.ignore[ruleNames[i]].addMatch(rule.match);
   }
 
   return this;
@@ -402,17 +404,17 @@ Bitloader.prototype.Logger     = Logger;
 Bitloader.prototype.Middleware = Middleware;
 
 // Expose constructors and utilities
-Bitloader.Promise     = Promise;
-Bitloader.Utils       = Utils;
-Bitloader.Registry    = Registry;
-Bitloader.Loader      = Loader;
-Bitloader.Import      = Import;
-Bitloader.Module      = Module;
-Bitloader.Plugin      = Plugin;
-Bitloader.Resolver    = Resolver;
-Bitloader.Fetcher     = Fetcher;
-Bitloader.Compiler    = Compiler;
-Bitloader.Middleware  = Middleware;
-Bitloader.RuleMatcher = RuleMatcher;
-Bitloader.Logger      = Logger;
-module.exports        = Bitloader;
+Bitloader.Promise    = Promise;
+Bitloader.Utils      = Utils;
+Bitloader.Registry   = Registry;
+Bitloader.Loader     = Loader;
+Bitloader.Import     = Import;
+Bitloader.Module     = Module;
+Bitloader.Plugin     = Plugin;
+Bitloader.Resolver   = Resolver;
+Bitloader.Fetcher    = Fetcher;
+Bitloader.Compiler   = Compiler;
+Bitloader.Middleware = Middleware;
+Bitloader.Rule       = Rule;
+Bitloader.Logger     = Logger;
+module.exports       = Bitloader;

--- a/src/meta/compile.js
+++ b/src/meta/compile.js
@@ -46,7 +46,7 @@ MetaCompile.compile = function(manager, moduleMeta) {
 
 
 function canProcess(manager, moduleMeta) {
-  return !manager.rules.ignore.match(moduleMeta.name, "compile");
+  return !manager.rules.ignore.compile.match(moduleMeta.name);
 }
 
 

--- a/src/meta/dependency.js
+++ b/src/meta/dependency.js
@@ -52,7 +52,7 @@ function loadDependencies(manager, moduleMeta) {
 
 
 function canProcess(manager, moduleMeta) {
-  return !manager.rules.ignore.match(moduleMeta.name, "dependency");
+  return !manager.rules.ignore.dependency.match(moduleMeta.name);
 }
 
 

--- a/src/meta/fetch.js
+++ b/src/meta/fetch.js
@@ -52,7 +52,7 @@ MetaFetch.fetch = function(manager, moduleMeta) {
 
 
 function canProcess(manager, moduleMeta) {
-  return !Utils.isString(moduleMeta.source) && !manager.rules.ignore.match(moduleMeta.name, "fetch");
+  return !Utils.isString(moduleMeta.source) && !manager.rules.ignore.fetch.match(moduleMeta.name);
 }
 
 

--- a/src/meta/transform.js
+++ b/src/meta/transform.js
@@ -30,7 +30,7 @@ MetaTransform.pipeline = function(manager, moduleMeta) {
 
 
 function canProcess(manager, moduleMeta) {
-  return Utils.isString(moduleMeta.source) && !manager.rules.ignore.match(moduleMeta.name, "transform");
+  return Utils.isString(moduleMeta.source) && !manager.rules.ignore.transform.match(moduleMeta.name);
 }
 
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,6 @@
-var Promise     = require("./promise");
-var Utils       = require("./utils");
-var RuleMatcher = require("./rule-matcher");
+var Promise = require("./promise");
+var Utils   = require("./utils");
+var Rule    = require("./rule-matcher");
 
 var pluginId = 0;
 
@@ -16,7 +16,6 @@ function Plugin(name, options) {
   this._matches   = {};
   this._delegates = {};
   this._handlers  = {};
-  this._deferred  = {};
 }
 
 
@@ -55,8 +54,8 @@ Plugin.prototype.configure = function(options, handlerVisitor) {
 Plugin.prototype.addMatchingRules = function(matchName, matches) {
   var rules;
   if (matches && matches.length) {
-    rules = this._matches[matchName] || (this._matches[matchName] = new RuleMatcher());
-    rules.add(configureMatchingRules(matches));
+    rules = this._matches[matchName] || (this._matches[matchName] = new Rule({name: matchName}));
+    rules.addMatch(configureMatchingRules(matches));
   }
 
   return this;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,36 +1,37 @@
 function noop() {
 }
 
-function isNull(item) {
+function isNil(item) {
   return item === null || item === (void 0);
 }
 
+function isNull(item) {
+  return item === null;
+}
+
 function isArray(item) {
-  return item instanceof(Array);
+  return item instanceof Array;
 }
 
 function isString(item) {
-  return typeof(item) === "string";
+  return typeof item === "string";
 }
 
 function isObject(item) {
-  return typeof(item) === "object";
+  return typeof item === "object";
 }
 
+var ObjectSignature = Object.prototype.toString();
 function isPlainObject(item) {
-  return !!item && !isArray(item) && (item.toString() === isPlainObject.signature);
+  return !!item && !isArray(item) && item.toString() === ObjectSignature;
 }
-
-// Cache result for quicker check
-isPlainObject.signature = Object.prototype.toString();
-
 
 function isFunction(item) {
-  return !isNull(item) && item.constructor === Function;
+  return !isNil(item) && item.constructor === Function;
 }
 
 function isDate(item) {
-  return item instanceof(Date);
+  return item instanceof Date;
 }
 
 function result(input, args, context) {
@@ -55,11 +56,11 @@ function toArray(items) {
  */
 function extend(target) {
   var source, length, i;
-  var sources = Array.prototype.slice.call(arguments, 1);
+  var sources = arguments;
   target = target || {};
 
   // Allow n params to be passed in to extend this object
-  for (i = 0, length  = sources.length; i < length; i++) {
+  for (i = 1, length  = sources.length; i < length; i++) {
     source = sources[i];
     for (var property in source) {
       if (source.hasOwnProperty(property)) {
@@ -72,24 +73,26 @@ function extend(target) {
 }
 
 /**
- * Deep copy of all properties insrouces into target
+ * Deep copy of all properties into target
  */
 function merge(target) {
   var source, length, i;
-  var sources = Array.prototype.slice.call(arguments, 1);
+  var sources = arguments;
   target = target || {};
 
   // Allow `n` params to be passed in to extend this object
-  for (i = 0, length  = sources.length; i < length; i++) {
+  for (i = 1, length  = sources.length; i < length; i++) {
     source = sources[i];
     for (var property in source) {
-      if (source.hasOwnProperty(property)) {
-        if (isPlainObject(source[property])) {
-          target[property] = merge(target[property], source[property]);
-        }
-        else {
-          target[property] = source[property];
-        }
+      if (!source.hasOwnProperty(property)) {
+        continue;
+      }
+
+      if (isPlainObject(source[property])) {
+        target[property] = merge(target[property], source[property]);
+      }
+      else {
+        target[property] = source[property];
       }
     }
   }
@@ -98,6 +101,9 @@ function merge(target) {
 }
 
 
+/**
+ * Logs error to the console and makes sure it is only logged once.
+ */
 function reportError(error) {
   if (error && !error.handled) {
     error.handled = true;
@@ -118,12 +124,13 @@ function forwardError(error) {
 }
 
 
-function notImplemented() {
-  throw new TypeError("Not implemented");
+function notImplemented(msg) {
+  throw new TypeError("Not implemented. " + msg);
 }
 
 
 module.exports = {
+  isNil: isNil,
   isNull: isNull,
   isArray: isArray,
   isString: isString,

--- a/test/config.js
+++ b/test/config.js
@@ -4,12 +4,13 @@ var require = (function() {
   var importer = bitimports.config({
     "baseUrl": "../",
     "paths": {
-      "chai": "../node_modules/chai/chai"
+      "chai": "node_modules/chai/chai",
+      "minimatch": "node_modules/minimatch/browser"
     }
   });
 
   importer.ignore({
-    match: ["chai", "dist/bit-loader"]
+    match: ["chai", "minimatch", "dist/bit-loader"]
   });
 
   bitimports.Logger.enableAll();

--- a/test/spec/plugin.js
+++ b/test/spec/plugin.js
@@ -1,4 +1,5 @@
 define(["dist/bit-loader"], function(Bitloader) {
+  var matcher = Bitloader.Rule.matcher;
 
   describe("Plugin Test Suite", function() {
     var bitloader;
@@ -17,12 +18,12 @@ define(["dist/bit-loader"], function(Bitloader) {
         var matchingRules, ruleName;
         beforeEach(function() {
           ruleName = "test";
-          matchingRules = ["**.js", "1.js"];
+          matchingRules = [matcher.extension("js"), matcher.string("1.js")];
           plugin.addMatchingRules(ruleName, matchingRules);
         });
 
         it("then `rules` are added to the plugin", function() {
-          expect(plugin._matches[ruleName]).to.be.an.instanceof(Bitloader.RuleMatcher);
+          expect(plugin._matches[ruleName]).to.be.an.instanceof(Bitloader.Rule);
         });
       });
     });
@@ -407,7 +408,7 @@ define(["dist/bit-loader"], function(Bitloader) {
 
         bitloader.plugin({
           "match": {
-            "path": ["**/*.js"]
+            "path": [matcher.extension("js")]
           },
           "resolve": [resolveStub1],
           "fetch": [
@@ -428,7 +429,7 @@ define(["dist/bit-loader"], function(Bitloader) {
 
         bitloader.plugin({
           "match": {
-            "path": ["**/*.jsx"]
+            "path": [matcher.extension("jsx")]
           },
           "transform": transformStub3,
           "dependency": dependencyStub2,


### PR DESCRIPTION
- Overhaul to remove the RuleMatcher component. Rules are built directly instead of through the level of indirection.
- Rules now specify matchers, which is a way to add matching rules of different types and even custom ones. For example, there is a built in matcher for extensions, another for strings, and another for regex.
- Removed minimatch from the core in favor of the extension matcher. A minimatch matcher can be really easily added as a custom matcher.