### PR TITLE
overhauled logger

### DIFF
--- a/example/asyncfile/fileReader.js
+++ b/example/asyncfile/fileReader.js
@@ -37,11 +37,8 @@ function readFile(filePath) {
       .setEncoding("utf8");
 
     stream
-      .on("readable", function() {
-        var chunk = stream.read();
-        if (chunk !== null) {
-          filecontent += chunk;
-        }
+      .on("data", function(chunk) {
+        filecontent += chunk;
       })
       .on("end", function() {
         resolve(filecontent);

--- a/example/asyncfile/index.js
+++ b/example/asyncfile/index.js
@@ -1,8 +1,16 @@
+var fs          = require("fs");
+var joint       = require("stream-joint");
+var Bitloader   = require("bit-loader");
 var fileReader  = require("./fileReader");
 var compiler    = require("./compiler");
 var resolvePath = require("./resolvePath");
-var Bitloader   = require("bit-loader");
 var Utils       = Bitloader.Utils;
+
+
+Bitloader.Logger
+  .enable()
+  .pipe(joint(process.stdout))
+  .pipe(joint(fs.createWriteStream('./temp.log')));
 
 
 var loader = new Bitloader({

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,8 @@
     "browser-pack": "^5.0.1",
     "browser-resolve": "^1.9.0",
     "deps-bits": "0.0.3",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "stream-joint": "^1.0.0"
   },
   "browser": {
     "react": "./node_modules/react/dist/react.min.js"

--- a/src/meta/compile.js
+++ b/src/meta/compile.js
@@ -2,7 +2,7 @@ var runPipeline = require("./runPipeline");
 var Promise     = require("../promise");
 var Module      = require("../module");
 var Utils       = require("../utils");
-var logger      = require("../logger").factory("Meta/Compiler");
+var logger      = require("../logger").create("Meta/Compiler");
 
 
 function MetaCompile() {

--- a/src/meta/dependency.js
+++ b/src/meta/dependency.js
@@ -2,7 +2,7 @@ var runPipeline = require("./runPipeline");
 var Promise     = require("../promise");
 var Module      = require("../module");
 var Utils       = require("../utils");
-var logger      = require("../logger").factory("Meta/Dependency");
+var logger      = require("../logger").create("Meta/Dependency");
 
 
 function MetaDependency() {

--- a/src/meta/fetch.js
+++ b/src/meta/fetch.js
@@ -1,7 +1,7 @@
 var runPipeline = require("./runPipeline");
 var Promise     = require("../promise");
 var Utils       = require("../utils");
-var logger      = require("../logger").factory("Meta/Fetch");
+var logger      = require("../logger").create("Meta/Fetch");
 
 
 function MetaFetch() {

--- a/src/meta/linker.js
+++ b/src/meta/linker.js
@@ -1,5 +1,5 @@
 var Module = require("../module");
-var logger = require("../logger").factory("Module/Linker");
+var logger = require("../logger").create("Module/Linker");
 
 
 /**

--- a/src/meta/resolve.js
+++ b/src/meta/resolve.js
@@ -1,7 +1,7 @@
 var runPipeline = require("./runPipeline");
 var Promise     = require("../promise");
 var Utils       = require("../utils");
-var logger      = require("../logger").factory("Meta/Resolve");
+var logger      = require("../logger").create("Meta/Resolve");
 
 
 function MetaResolve() {

--- a/src/meta/transform.js
+++ b/src/meta/transform.js
@@ -1,7 +1,7 @@
 var runPipeline = require("./runPipeline");
 var Promise     = require("../promise");
 var Utils       = require("../utils");
-var logger      = require("../logger").factory("Meta/Transform");
+var logger      = require("../logger").create("Meta/Transform");
 
 
 function MetaTransform() {


### PR DESCRIPTION
1. Added better support for streams by providing a `pipe` method to
override the current stream.
2. Redid the priority for global stream vs local stream. Local streams
will always have precedence over global stream.
3. Added `find` method to get a hold of particular loggers by name.
4. Logger operations are more chain able.