### PR TITLE
Add local grunt-cli, build before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
 - '0.10'
-before_install:
-- npm install -g grunt-cli
 deploy:
   provider: releases
   api_key:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-tap": "^1.0.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "~4.0.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "~2.0.1",
     "grunt-contrib-connect": "~0.11.2",
     "grunt-contrib-jshint": "~0.11.2",


### PR DESCRIPTION
It's polite to those of us who do not have `grunt-cli` installed globally, to install locally in devDependencies.  :)

This also now performs a build before running tests, since without it the tests were failing on my box. Plus now you'll get linting prior to the tests.  