### PR TITLE
Removed `g` from the regex expression because it causes issues runnin…

### DIFF
--- a/src/matches.js
+++ b/src/matches.js
@@ -13,7 +13,7 @@ Matches.prototype.configure = function(options) {
 
   if (options.extensions) {
     var extensions = types.isArray(options.extensions) ? options.extensions : [options.extensions];
-    this.match("path", new RegExp("[\\w]+\\.(" + extensions.join("|") + ")$", "gmi"));
+    this.match("path", new RegExp("[\\w]+\\.(" + extensions.join("|") + ")$", "mi"));
   }
 
   for (prop in options.match) {


### PR DESCRIPTION
…g the same regex instance multiple times

open chrome dev console and run the following commands

```
> t = new RegExp("[\\w]+\\.(js)$", "gmi")
> t.test("mi.js")
> t.test("mi.js")
```