### PR TITLE
Dynamic plugins

### DIFF
--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -262,13 +262,9 @@ Bitloader.prototype.getSource = function(names, referrer) {
   return this.controllers.fetcher
     .fetch(names, referrer)
     .then(function(moduleMetas) {
-      if (types.isString(names)) {
-        return loader.getModule(moduleMetas.id).source;
-      }
-
-      return moduleMetas.map(function(moduleMeta) {
-        return loader.getModule(moduleMeta.id).source;
-      });
+      return types.isArray(moduleMetas) ?
+        moduleMetas.map(function(moduleMeta) { return loader.getModule(moduleMeta.id).source; }) :
+        loader.getModule(moduleMetas.id).source;
     });
 };
 
@@ -461,13 +457,17 @@ Bitloader.prototype.ignore = function(rules) {
  *   }
  * });
  */
-Bitloader.prototype.plugin = function(name, settings) {
-  if (types.isPlainObject(name) || types.isFunction(name)) {
-    settings = name;
-    name = settings.name;
+Bitloader.prototype.plugin = function(id, settings) {
+  if (types.isPlainObject(id)) {
+    settings = id;
+    id = settings.name;
+  }
+  else if (types.isFunction(id)) {
+    settings = id;
+    id = null;
   }
 
-  this.plugins.configurePlugin(name, settings);
+  this.plugins.configurePlugin(id, settings);
   return this;
 };
 

--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -56,7 +56,7 @@ function Bitloader(options) {
     builder  : new Builder(this)
   };
 
-  this.plugins = new Plugins(this, this.services);
+  this.plugins = new Plugins(this, utils.omit(this.services, ["compile", "link"]));
   this.merge(options);
 }
 

--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -12,6 +12,7 @@ var Dependency   = require("./services/dependency");
 var PreCompile   = require("./services/precompile");
 var Compile      = require("./services/compile");
 
+var Controller = require("./controller");
 var Fetcher    = require("./controllers/fetcher");
 var Importer   = require("./controllers/importer");
 var Loader     = require("./controllers/loader");
@@ -40,21 +41,15 @@ function Bitloader(options) {
   this.cache = {};
 
   // Services! Components that process modules.
-  this.services = utils.merge({},
+  this.services = utils.extend({},
     Service.create(this, { resolve: Resolve, fetch: Fetch, transform: Transform, dependency: Dependency }, true),
     Service.create(this, { precompile: PreCompile, compile: Compile, link: Link })
   );
 
-  // Controllers!  These guys make use of the services to build pipelines
-  // that build modules. Controllers use services, but services only use
-  // services, not controllers.
-  this.controllers = {
-    fetcher  : new Fetcher(this),
-    loader   : new Loader(this),
-    importer : new Importer(this),
-    registry : new Registry(this),
-    builder  : new Builder(this)
-  };
+  // Controllers! These guys make use of the services to build pipelines
+  // that build modules. Controllers use services in order to orchestrate
+  // workflows.
+  this.controllers = Controller.create(this, { fetcher: Fetcher, loader: Loader, importer: Importer, registry: Registry, builder: Builder });
 
   this.plugins = new Plugins(this, utils.omit(this.services, ["compile", "link"]));
   this.merge(options);

--- a/src/controller.js
+++ b/src/controller.js
@@ -6,4 +6,13 @@ function Controller(context) {
   this.context = context;
 }
 
+Controller.create = function(context, controllers) {
+  return Object
+    .keys(controllers)
+    .reduce(function(result, controller) {
+      result[controller] = new controllers[controller](context);
+      return result;
+    }, {});
+};
+
 module.exports = Controller;

--- a/src/plugin/handler.js
+++ b/src/plugin/handler.js
@@ -33,11 +33,6 @@ function Handler(options) {
 inherit.base(Handler).extends(HandlerBlueprint);
 
 
-Handler.prototype.isDynamic = function() {
-  return types.isString(this.handler);
-};
-
-
 /**
  * Configures handler with the provided options.
  */

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -30,8 +30,7 @@ inherit.base(Plugin).extends(PluginBlueprint);
 
 Plugin.prototype.configure = function(options) {
   var plugin = this;
-  var configuration = configurePlugin(options);
-  var services = utils.pick(configuration, this.context.getServiceNames());
+  var services = utils.pick(options, this.context.services);
 
   var handlers = Object
     .keys(services)
@@ -63,7 +62,7 @@ Plugin.prototype.configure = function(options) {
 
   return this
     .merge({ handlers: handlers })
-    .merge({ matchers: this.matchers.configure(configuration.matchers || configuration) });
+    .merge({ matchers: this.matchers.configure(options.matchers || options) });
 };
 
 
@@ -132,19 +131,6 @@ Plugin.prototype.serialize = function() {
 
   return utils.merge(utils.pick(this, ["id"]), handlers);
 };
-
-
-function configurePlugin(options) {
-  if (types.isFunction(options)) {
-    options = options(new Builder());
-
-    if (options instanceof Builder) {
-      options = options.build();
-    }
-  }
-
-  return options;
-}
 
 
 function configureHandler(options) {

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -1,6 +1,7 @@
 var utils = require("belty");
 var types = require("dis-isa");
 var Builder = require("./builder");
+var Handler = require("./handler");
 var Matches = require("../matches");
 var inherit = require("../inherit");
 var blueprint = require("../blueprint");
@@ -31,38 +32,17 @@ inherit.base(Plugin).extends(PluginBlueprint);
 Plugin.prototype.configure = function(options) {
   var plugin = this;
   var services = utils.pick(options, this.context.services);
+  var handlers = {};
 
-  var handlers = Object
-    .keys(services)
-    .map(function(serviceName) {
-      return {
-        serviceName: serviceName,
-        handlers: plugin.handlers[serviceName]
-      };
-    })
-    .reduce(function(result, handlersConfig) {
-      var serviceName = handlersConfig.serviceName;
-      var handlers = handlersConfig.handlers;
+  Object.keys(services).forEach(function(serviceName) {
+    var pluginHandlers = plugin.handlers[serviceName] || [];
+    handlers[serviceName] = pluginHandlers.concat(configureHandler(services[serviceName]));
+  });
 
-      if (!handlers) {
-        handlers = [];
-        plugin.context.registerPluginWithService(serviceName, plugin.id);
-      }
-
-      var handlerIds = utils
-        .toArray(services[serviceName])
-        .map(function(config) {
-          var handler = plugin.context.configureHandler(config.id, configureHandler(config));
-          return handler.id;
-        });
-
-      result[serviceName] = handlers.concat(handlerIds);
-      return result;
-    }, {});
-
-  return this
-    .merge({ handlers: handlers })
-    .merge({ matchers: this.matchers.configure(options.matchers || options) });
+  return this.merge({
+    handlers: handlers,
+    matchers: this.matchers.configure(options.matchers || options)
+  });
 };
 
 
@@ -83,7 +63,7 @@ Plugin.prototype.run = function(serviceName, data) {
   }
 
   if (!handlers) {
-    throw new Error("Service '" + serviceName + "' has no registered handlers unknown");
+    throw new Error("Service '" + serviceName + "' has no registered handlers");
   }
 
   function cancel() {
@@ -96,53 +76,39 @@ Plugin.prototype.run = function(serviceName, data) {
     }
   }
 
-  return plugin.context.loadHandlers().then(function() {
-    return handlers
-      .map(function(id) {
-        return plugin.context.getHandler(id);
-      })
-      .reduce(function(current, handler) {
-        return current
-          .then(canRun)
-          .then(runHandler(handler, cancel));
-      }, Promise.resolve(data));
-  });
+  return handlers.reduce(function(current, handler) {
+    return current
+      .then(canRun)
+      .then(runHandler(handler, cancel));
+  }, Promise.resolve(data));
 };
 
 
 Plugin.prototype.serialize = function() {
   var plugin = this;
+  var handlers = {};
 
-  var handlers = Object
-    .keys(plugin.handlers)
-    .map(function(serviceName) {
-      return {
-        serviceName: serviceName,
-        handlers: plugin.handlers[serviceName]
-      };
-    })
-    .reduce(function(result, handlersConfig) {
-      result[handlersConfig.serviceName] = handlersConfig.handlers.map(function(handlerId) {
-        return plugin.context.getHandler(handlerId).serialize();
-      });
+  Object.keys(plugin.handlers).forEach(function(serviceName) {
+    handlers[serviceName] = plugin.handlers[serviceName].map(function(handler) {
+      return handler.serialize();
+    });
+  });
 
-      return result;
-    }, {});
-
-  return utils.merge(utils.pick(this, ["id"]), handlers);
+  return utils.merge({id: plugin.id}, handlers);
 };
 
 
 function configureHandler(options) {
-  if (types.isFunction(options) || types.isString(options)) {
-    options = {
-      handler: options
-    };
-  }
+  return [].concat(options).map(function(opt) {
+    if (types.isFunction(opt) || types.isString(opt)) {
+      opt = {
+        handler: opt
+      };
+    }
 
-  return options;
+    return new Handler(opt);
+  });
 }
-
 
 
 /**

--- a/src/plugin/registrar.js
+++ b/src/plugin/registrar.js
@@ -41,8 +41,7 @@ Registrar.prototype._items = function(ids, container) {
 
 Registrar.prototype.configurePlugin = function(id, options) {
   if (types.isFunction(options)) {
-    var servicesMap = this
-      .getServiceNames()
+    var servicesMap = Object.keys(this.services)
       .reduce(function(result, name) {
         result[name] = [];
         return result;
@@ -55,19 +54,9 @@ Registrar.prototype.configurePlugin = function(id, options) {
     }
   }
 
-  id = id || options.id;
-
-  if (!id) {
-    id = "plugin-" + _pluginId++;
-  }
-
+  id = id || options.id || "plugin-" + _pluginId++;
   this.plugins[id] = this._configure(id, options, this.plugins, Plugin);
   return this.plugins[id];
-};
-
-
-Registrar.prototype.getServiceNames = function() {
-  return Object.keys(this.services);
 };
 
 
@@ -87,10 +76,7 @@ Registrar.prototype.getPlugins = function(ids) {
 
 
 Registrar.prototype.configureHandler = function(id, options) {
-  if (!id) {
-    id = "handler-" + _handlerId++;
-  }
-
+  id = id || options.id || "handler-" + _handlerId++;
   this.handlers[id] = this._configure(id, options, this.handlers, Handler);
   return this.handlers[id];
 };

--- a/src/plugin/registrar.js
+++ b/src/plugin/registrar.js
@@ -1,12 +1,10 @@
 var logger = require("loggero").create("plugin/registrar");
 var Plugin = require("./plugin");
-var Handler = require("./handler");
 var Builder = require("./builder");
 var utils = require("belty");
 var types = require("dis-isa");
 
 var _pluginId = 1;
-var _handlerId = 1;
 
 
 /**
@@ -17,25 +15,11 @@ function Registrar(context, services) {
   this.context = context;
   this.services = services;
   this.plugins = {};
-  this.handlers = {};
 }
 
 
 Registrar.prototype.configure = function(options) {
-  return utils.merge(this, utils.pick(options, ["plugins", "handlers"]));
-};
-
-
-Registrar.prototype._configure = function(id, options, container, Constructor) {
-  var item = container[id] || new Constructor({ context: this, id: id });
-  return item.configure(options);
-};
-
-
-Registrar.prototype._items = function(ids, container) {
-  return (ids || Object.keys(container)).map(function(id) {
-    return container[id];
-  });
+  return utils.merge(this, utils.pick(options, ["plugins"]));
 };
 
 
@@ -55,7 +39,21 @@ Registrar.prototype.configurePlugin = function(id, options) {
   }
 
   id = id || options.id || "plugin-" + _pluginId++;
-  this.plugins[id] = this._configure(id, options, this.plugins, Plugin);
+
+  var currentPlugin = this.plugins[id] || new Plugin({ context: this, id: id });
+  var updatedPlugin = currentPlugin.configure(options);
+  var registrar = this;
+
+  Object
+    .keys(updatedPlugin.handlers)
+    .filter(function(serviceName) {
+      return !currentPlugin.handlers[serviceName];
+    })
+    .forEach(function(serviceName) {
+      registrar.registerPluginWithService(serviceName, id);
+    });
+
+  this.plugins[id] = updatedPlugin;
   return this.plugins[id];
 };
 
@@ -71,76 +69,11 @@ Registrar.prototype.getPlugin = function(id) {
 
 
 Registrar.prototype.getPlugins = function(ids) {
-  return this._items(ids, this.plugins);
-};
-
-
-Registrar.prototype.configureHandler = function(id, options) {
-  id = id || options.id || "handler-" + _handlerId++;
-  this.handlers[id] = this._configure(id, options, this.handlers, Handler);
-  return this.handlers[id];
-};
-
-
-Registrar.prototype.hasHandler = function(id) {
-  return this.handlers.hasOwnProperty(id);
-};
-
-
-Registrar.prototype.getHandler = function(id) {
-  return this.handlers[id];
-};
-
-
-Registrar.prototype.getHandlers = function(ids) {
-  return this._items(ids, this.handlers);
-};
-
-
-Registrar.prototype.loadHandlers = function(ids) {
-  if (this.pending) {
-    return Promise.resolve();
-  }
-
   var registrar = this;
-  var handlers  = registrar.getHandlers(ids);
-  var dynamicHandlers = Object
-    .keys(handlers)
-    .filter(function(key) {
-      return handlers[key].isDynamic();
-    })
-    .map(function(key) {
-      return handlers[key];
-    });
 
-  if (dynamicHandlers.length) {
-    var dynamicHandlerNames = dynamicHandlers
-      .map(function(handler) {
-        return handler.handler;
-      });
-
-    logger.log("loading", dynamicHandlerNames);
-
-    dynamicHandlers.forEach(function(handler) {
-      // While the plugin is loading, it cannot process anything. So we will
-      // default any calls to it to pass thru. This is in a separate context
-      // than application modules, so the only modules that are pass thru
-      // are module dependencies for the plugin themselves.
-      registrar.configureHandler(handler.id, { handler: utils.noop });
-    });
-
-    registrar.pending = registrar.context
-      .import(dynamicHandlerNames)
-      .then(updateLoadedHandlers(this, dynamicHandlers))
-      .then(function() {
-        logger.log("loaded", dynamicHandlerNames);
-        delete registrar.pending;
-      });
-
-    return registrar.pending;
-  }
-
-  return Promise.resolve();
+  return (ids || Object.keys(registrar.plugins)).map(function(id) {
+    return registrar.plugins[id];
+  });
 };
 
 
@@ -170,15 +103,6 @@ Registrar.prototype.serialize = function() {
     return plugin.serialize();
   });
 };
-
-
-function updateLoadedHandlers(registrar, handlers) {
-  return function(result) {
-    handlers.forEach(function(handler, i) {
-      registrar.configureHandler(handler.id, { handler: result[i] });
-    });
-  };
-}
 
 
 module.exports = Registrar;

--- a/src/plugin/registrar.js
+++ b/src/plugin/registrar.js
@@ -43,9 +43,6 @@ Registrar.prototype.configurePlugin = function(id, options) {
   if (types.isFunction(options)) {
     var servicesMap = this
       .getServiceNames()
-      .filter(function(name) {
-        return name !== "compile" && name !== "link";
-      })
       .reduce(function(result, name) {
         result[name] = [];
         return result;

--- a/test/spec/plugin/handler.js
+++ b/test/spec/plugin/handler.js
@@ -139,10 +139,6 @@ describe("Plugin Handler suite", () => {
       expect(handler.handler).to.equal(handlerString);
     });
 
-    it("then handler.handler is dynamic", () => {
-      expect(handler.isDynamic()).to.be.true;
-    });
-
     it("then handler.matches is an instance of Matches", () => {
       expect(handler.matchers).to.be.instanceof(Matches);
     });
@@ -180,10 +176,6 @@ describe("Plugin Handler suite", () => {
 
     it("then handler.handler is properly set to the input function", () => {
       expect(handler.handler).to.equal(handlerFunction);
-    });
-
-    it("then handler.handler is NOT dynamic", () => {
-      expect(handler.isDynamic()).to.be.false;
     });
 
     it("then handler.matches is an instance of Matches", () => {
@@ -233,10 +225,6 @@ describe("Plugin Handler suite", () => {
 
     it("then handler.handler is properly set to the input function", () => {
       expect(handler.handler).to.equal(handlerFunction);
-    });
-
-    it("then handler.handler is NOT dynamic", () => {
-      expect(handler.isDynamic()).to.be.false;
     });
 
     it("then handler.matches is an instance of Matches", () => {

--- a/test/spec/plugin/plugin.js
+++ b/test/spec/plugin/plugin.js
@@ -45,7 +45,7 @@ describe("Plugin Test Suite", function() {
       serviceName = chance.word();
       configurePlugin = () => plugin = plugin.configure(pluginOptions);
       registrarMock = new Registrar();
-      registrarMock.getServiceNames = sinon.stub().returns([serviceName]);
+      registrarMock.services = [serviceName];
       registrarMock.registerPluginWithService = sinon.stub();
       createPlugin();
     });
@@ -201,7 +201,7 @@ describe("Plugin Test Suite", function() {
         handlerResult = { "source": chance.string() };
         handler = sinon.stub().returns(handlerResult);
         registrarMock = new Registrar();
-        registrarMock.getServiceNames = sinon.stub().returns(["transform"]);
+        registrarMock.services = ["transform"];
         registrarMock.registerPluginWithService = sinon.stub();
 
         createPlugin();
@@ -258,7 +258,7 @@ describe("Plugin Test Suite", function() {
         loader.import = importStub;
         loader.config = sinon.stub().returns(loader);
         registrarMock = new Registrar(loader);
-        registrarMock.getServiceNames = sinon.stub().returns(["transform"]);
+        registrarMock.services = ["transform"];
         registrarMock.registerPluginWithService = sinon.stub();
 
         createPlugin();
@@ -312,7 +312,7 @@ describe("Plugin Test Suite", function() {
         loader.import = importStub;
         loader.config = sinon.stub().returns(loader);
         registrarMock = new Registrar(loader);
-        registrarMock.getServiceNames = sinon.stub().returns(["transform"]);
+        registrarMock.services = ["transform"];
         registrarMock.registerPluginWithService = sinon.stub();
 
         createPlugin();
@@ -371,7 +371,7 @@ describe("Plugin Test Suite", function() {
         loader.import = importStub;
         loader.config = sinon.stub().returns(loader);
         registrarMock = new Registrar(loader);
-        registrarMock.getServiceNames = sinon.stub().returns(["transform"]);
+        registrarMock.services = ["transform"];
         registrarMock.registerPluginWithService = sinon.stub();
 
         createPlugin();
@@ -428,7 +428,7 @@ describe("Plugin Test Suite", function() {
         loader.import = importStub;
         loader.config = sinon.stub().returns(loader);
         registrarMock = new Registrar(loader);
-        registrarMock.getServiceNames = sinon.stub().returns(["transform"]);
+        registrarMock.services = ["transform"];
         registrarMock.registerPluginWithService = sinon.stub();
 
         createPlugin();


### PR DESCRIPTION
This PR removes dynamic loading of plugin handlers. This is primarily to just simplify the code base and the workflow for working with bit-loader. The preferred approach is to passed in plugins with all handler functions eagerly configured.  This means that bit-imports is affected in that it will no longer be able to dynamically load plugin handlers.  The approach moving forward will be to bundle bit-imports configuration to eagerly load plugins and package the whole thing together as a runtime.