### PR TITLE
changed fetch API to return the actual cache module instead of initia…

### DIFF
--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -32,7 +32,12 @@ Fetcher.prototype.fetch = function(names, referrer) {
       return Promise.all(moduleMetas.map(runFetchPipeline(fetcher)));
     })
     .then(function(moduleMetas) {
-      return types.isArray(names) ? moduleMetas : moduleMetas[0];
+      return moduleMetas.map(function(moduleMeta) {
+        return fetcher.context.controllers.registry.getModule(moduleMeta.id);
+      })
+    })
+    .then(function(modules) {
+      return types.isArray(names) ? modules : modules[0];
     });
 };
 
@@ -45,7 +50,12 @@ Fetcher.prototype.fetchOnly = function(names, referrer) {
       return Promise.all(moduleMetas.map(fetchService(fetcher.context)));
     })
     .then(function(moduleMetas) {
-      return types.isArray(names) ? moduleMetas : moduleMetas[0];
+      return moduleMetas.map(function(moduleMeta) {
+        return fetcher.context.controllers.registry.getModule(moduleMeta.id);
+      })
+    })
+    .then(function(modules) {
+      return types.isArray(names) ? modules : modules[0];
     });
 };
 

--- a/test/spec/fetch.js
+++ b/test/spec/fetch.js
@@ -158,18 +158,33 @@ describe("Fetch Test Suite", function() {
       sinon.assert.calledWith(precompileStub, sinon.match(transformCommonData));
     });
 
+    it("then the module contains the expected referrer", function() {
+      expect(result.referrer).to.eql({});
+    });
+
+    it("then the module has two dependencies", function() {
+      expect(result.deps).to.have.lengthOf(2)
+    });
+
+    it("then one of the dependencies is dep1", function() {
+      expect(result.deps[0]).to.deep.include({ name: "dep1" });
+    });
+
+    it("then one of the dependencies is common-dep", function() {
+      expect(result.deps[1]).to.deep.include({ name: "common-dep" });
+    });
+
     it("then the result will have all the aggregated data", function() {
-      expect(result).to.eql(new Module({
-        deps: [],
+      expect(result).to.include({
         directory: "this is the real path to like/",
         filename: "like-name",
         id: "like-id",
         name: "like",
         path: "this is the real path to like/like-name",
-        referrer: {},
-        state: "resolve",
+        state: "loaded",
+        source: "precompiled source",
         type: "UNKNOWN"
-      }));
+      });
     });
 
     describe("and reading the loaded `like` module", function() {


### PR DESCRIPTION
…l module meta

Previously, modules were return with the initial meta data. Now we are returning the actual processed module. This makes the API more concise.