### PR TITLE
load a module by using its source

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "env": {
-    "browser": true
+    "browser": true,
+    "commonjs": true
   },
   "rules": {
     "curly": 2,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bit-loader",
   "version": "7.1.3",
   "description": "Framework for building module loaders with very little effort for noobs",
-  "main": "src/bit-loader.js",
+  "main": "dist/index.js",
   "directories": {
     "test": "tests"
   },

--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -191,6 +191,11 @@ Bitloader.prototype.fetchOnly = function(names, referrer) {
 };
 
 
+Bitloader.prototype.fetchFromSource = function(source, referrer) {
+  return this.controllers.fetcher.fromSource(source, referrer);
+};
+
+
 /**
  * Method for importing modules.
  *
@@ -294,6 +299,12 @@ Bitloader.prototype.getSource = function(names, referrer) {
         moduleMetas.map(function(moduleMeta) { return loader.getModule(moduleMeta.id).source; }) :
         loader.getModule(moduleMetas.id).source;
     });
+};
+
+
+/** Method to initiate the process of loading a module from a content string rather than a module name */
+Bitloader.prototype.loadFromSource = function(source, referrer) {
+  return this.controllers.loader.fromSource(source, referrer);
 };
 
 

--- a/src/bit-loader.js
+++ b/src/bit-loader.js
@@ -154,15 +154,8 @@ Bitloader.prototype.merge = function(options) {
  *
  * @returns {Promise} That when resolved it returns the loaded module meta objects
  */
-Bitloader.prototype.fetch = function(names, referrer) {
-  const file = configureFile(names);
-
-  if (file.paths) {
-    return this.controllers.fetcher.loadNames(file.paths, referrer, true);
-  }
-  else if (file.content) {
-    return this.controllers.fetcher.loadSource(file.content, referrer, true);
-  }
+Bitloader.prototype.fetch = function(file, referrer) {
+  return this.controllers.fetcher.fetch(file, referrer, true);
 };
 
 
@@ -177,15 +170,8 @@ Bitloader.prototype.fetch = function(names, referrer) {
  *
  * @returns {Promise} That when resolved it returns the loaded module meta objects
  */
-Bitloader.prototype.fetchShallow = function(names, referrer) {
-  const file = configureFile(names);
-
-  if (file.paths) {
-    return this.controllers.fetcher.loadNames(file.paths, referrer, false);
-  }
-  else if (file.content) {
-    return this.controllers.fetcher.loadSource(file.content, referrer, false);
-  }
+Bitloader.prototype.fetchShallow = function(file, referrer) {
+  return this.controllers.fetcher.fetch(file, referrer, false);
 };
 
 
@@ -201,11 +187,7 @@ Bitloader.prototype.fetchShallow = function(names, referrer) {
  * @returns {Promise} That when resolved it returns the loaded module meta objects
  */
 Bitloader.prototype.fetchOnly = function(names, referrer) {
-  const file = configureFile(names);
-
-  if (file.paths) {
-    return this.controllers.fetcher.fetchOnly(file.paths, referrer);
-  }
+  return this.controllers.fetcher.fetchOnly(names, referrer);
 };
 
 
@@ -219,15 +201,24 @@ Bitloader.prototype.fetchOnly = function(names, referrer) {
  *
  * @returns {Promise} That when resolved it returns the modules' exports.
  */
-Bitloader.prototype.import = function(names, referrer) {
-  const file = configureFile(names);
+Bitloader.prototype.import = function(file, referrer) {
+  return this.controllers.importer.import(file, referrer);
+};
 
-  if (file.paths) {
-    return this.controllers.importer.importNames(file.paths, referrer);
-  }
-  else if (file.content) {
-    return this.controllers.importer.importSource(file.content, referrer);
-  }
+
+/**
+ * Method for importing modules. Unlike @see {@link import}, this method returns the module
+ * instance instead of the module's exports.
+ *
+ * @param {string|string[]} names - Names of the modules to import.
+ *
+ * @param {{path: string, name: string}} referrer - Module requesting the module. Usually
+ *  needed for processing relative paths.
+ *
+ * @returns {Pormise} When resolved it returns the full module instances.
+ */
+Bitloader.prototype.load = function(file, referrer) {
+  return this.controllers.loader.load(file, referrer);
 };
 
 
@@ -251,29 +242,6 @@ Bitloader.prototype.resolve = function(name, referrer) {
     .then(function(moduleMeta) {
       return moduleMeta.path;
     });
-};
-
-
-/**
- * Method for importing modules. Unlike @see {@link import}, this method returns the module
- * instance instead of the module's exports.
- *
- * @param {string|string[]} names - Names of the modules to import.
- *
- * @param {{path: string, name: string}} referrer - Module requesting the module. Usually
- *  needed for processing relative paths.
- *
- * @returns {Pormise} When resolved it returns the full module instances.
- */
-Bitloader.prototype.load = function(names, referrer) {
-  const file = configureFile(names);
-
-  if (file.paths) {
-    return this.controllers.loader.loadNames(file.paths, referrer);
-  }
-  else if (file.content) {
-    return this.controllers.loader.loadSource(file.content, referrer);
-  }
 };
 
 
@@ -549,26 +517,6 @@ function configureLogger(options) {
     if (options.hasOwnProperty("level")) {
       logger.level(logger.levels[options.level]);
     }
-  }
-}
-
-
-function configureFile(file) {
-  if (!file) {
-    throw new TypeError("Must provide a valid input. String, Array<String>, { src: Array<String> }, { content: String | Buffer }")
-  }
-
-  if (types.isString(file) || types.isArray(file)) {
-    return { paths: file };
-  }
-  else if (types.isArray(file.src) && file.src.length) {
-    return { paths: file.src };
-  }
-  else if (types.isString(file.content) || types.isBuffer(file.content)) {
-    return { content: file.content.toString() };
-  }
-  else if (types.isString(file.source) || types.isBuffer(file.source)) {
-    return { content: file.source.toString() };
   }
 }
 

--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -17,7 +17,7 @@ function Fetcher(context) {
 inherit.base(Fetcher).extends(Controller);
 
 
-Fetcher.prototype.fetch = function(names, referrer, deep) {
+Fetcher.prototype.loadNames = Fetcher.prototype.fetch = function(names, referrer, deep) {
   return this._loadModules(names, referrer, deep, [fetchService, transformService, dependencyService, precompileService]);
 };
 
@@ -27,8 +27,8 @@ Fetcher.prototype.fetchOnly = function(names, referrer, deep) {
 };
 
 
-Fetcher.prototype.fromSource = function(source, referrer) {
-  return this._loadModules({ source: source, id: id++ }, referrer, true, [fetchService, transformService, dependencyService, precompileService]);
+Fetcher.prototype.loadSource = function(source, referrer, deep) {
+  return this._loadModules({ source: source, id: id++ }, referrer, deep, [fetchService, transformService, dependencyService, precompileService]);
 };
 
 

--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -7,6 +7,8 @@ var Controller = require("../controller");
 var Pipeline   = require("then-pipeline");
 var utils      = require("belty");
 
+var id = 0;
+
 function Fetcher(context) {
   Controller.call(this, context);
   this.inProgress = {};
@@ -23,6 +25,11 @@ Fetcher.prototype.fetch = function(names, referrer, deep) {
 
 Fetcher.prototype.fetchOnly = function(names, referrer, deep) {
   return this._loadModules(names, referrer, deep, [fetchService]);
+};
+
+
+Fetcher.prototype.fromSource = function(source, referrer) {
+  return this._loadModules({ source: source, id: id++ }, referrer, true, [fetchService, transformService, dependencyService, precompileService]);
 };
 
 

--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -4,7 +4,6 @@ var inherit    = require("../inherit");
 var helpers    = require("./helpers");
 var Module     = require("../module");
 var Controller = require("../controller");
-var Pipeline   = require("then-pipeline");
 var utils      = require("belty");
 
 var id = 0;
@@ -49,11 +48,11 @@ Fetcher.prototype._buildTree = function(modules, referrer, services) {
             return this
               ._buildTree(mod1.deps, mod1, services)
               .then(deps => this.context.controllers.registry.updateModule(mod1.configure({ deps: deps })))
-              .then(() => mod)
+              .then(() => mod);
           }))
         )
         .then(() => modules)
-    )
+    );
 };
 
 

--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -28,7 +28,7 @@ Fetcher.prototype.fetchOnly = function(names, referrer, deep) {
 
 
 Fetcher.prototype.loadSource = function(source, referrer, deep) {
-  return this._loadModules({ source: source, id: id++ }, referrer, deep, [fetchService, transformService, dependencyService, precompileService]);
+  return this._loadModules({ source: source, id: "@anonymous-" + id++ }, referrer, deep, [fetchService, transformService, dependencyService, precompileService]);
 };
 
 
@@ -180,7 +180,7 @@ function getIfReady(fetcher, mod) {
 
 
 function runPipeline(fetcher, mod, services) {
-  logger.info(mod.name, mod);
+  logger.info(mod.name || mod.id, mod);
 
   function deleteInProgress() {
     delete fetcher.inProgress[mod.id];

--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -9,15 +9,7 @@ var utils      = require("belty");
 
 function Fetcher(context) {
   Controller.call(this, context);
-
   this.inProgress = {};
-
-  this.pipeline = new Pipeline([
-    fetchService(context),
-    transformService(context),
-    dependencyService(context),
-    precompileService(context)
-  ]);
 }
 
 
@@ -25,48 +17,62 @@ inherit.base(Fetcher).extends(Controller);
 
 
 Fetcher.prototype.fetch = function(names, referrer, deep) {
-  var fetcher = this;
-
-  return resolveNames(this, utils.toArray(names), referrer)
-    .then(function(moduleMetas) {
-      return Promise.all(moduleMetas.map(runFetchPipeline(fetcher, deep)));
-    })
-    .then(function(moduleMetas) {
-      return moduleMetas.map(function(moduleMeta) {
-        return fetcher.context.controllers.registry.getModule(moduleMeta.id);
-      });
-    })
-    .then(function(modules) {
-      return types.isArray(names) ? modules : modules[0];
-    });
+  return this._loadModules(names, referrer, deep, [fetchService, transformService, dependencyService, precompileService]);
 };
 
 
-Fetcher.prototype.fetchOnly = function(names, referrer) {
-  var fetcher = this;
-
-  return resolveNames(this, utils.toArray(names), referrer)
-    .then(function(moduleMetas) {
-      return Promise.all(moduleMetas.map(fetchService(fetcher.context)));
-    })
-    .then(function(moduleMetas) {
-      return moduleMetas.map(function(moduleMeta) {
-        return fetcher.context.controllers.registry.getModule(moduleMeta.id);
-      });
-    })
-    .then(function(modules) {
-      return types.isArray(names) ? modules : modules[0];
-    });
+Fetcher.prototype.fetchOnly = function(names, referrer, deep) {
+  return this._loadModules(names, referrer, deep, [fetchService]);
 };
 
 
-function resolveNames(fetcher, names, referrer) {
+Fetcher.prototype._buildTree = function(modules, referrer, services) {
+  return Promise
+    .all(this.resolveModules(modules, referrer, services))
+    .then(modules =>
+      Promise
+        .all(modules
+          .filter(mod => !getIfReady(this, mod) && !getInProgress(this, mod))
+          .map(mod => runPipeline(this, mod, services))
+        )
+        .then(modules => Promise.all(
+          modules.map(mod => {
+            var mod1 = this.context.controllers.registry.getModule(mod.id);
+  
+            return this
+              ._buildTree(mod1.deps, mod1, services)
+              .then(deps => this.context.controllers.registry.updateModule(mod1.configure({ deps: deps })))
+              .then(() => mod)
+          }))
+        )
+        .then(() => modules)
+    )
+};
+
+
+Fetcher.prototype._buildNodes = function(modules, referrer, services) {
   return Promise.all(
-    names
-      .map(configureModuleMeta(fetcher, referrer))
-      .map(resolveMetaModule(fetcher))
+    this
+      .resolveModules(modules, referrer)
+      .map(deferred => deferred.then(mod => getIfReady(this, mod) || getInProgress(this, mod) || runPipeline(this, mod, services)))
   );
-}
+};
+
+
+Fetcher.prototype._loadModules = function(modules, referrer, deep, services) {
+  services = services.map(service => service(this.context));
+  const deferred = deep === false ? this._buildNodes([].concat(modules), referrer, services) : this._buildTree([].concat(modules), referrer, services);
+  return deferred.then((result) => buildResult(this, modules, result));
+};
+
+
+Fetcher.prototype.resolveModules = function(modules, referrer) {
+  return (
+    modules
+      .map(configureModuleMeta(this, referrer))
+      .map(resolveMetaModule(this))
+  );
+};
 
 
 function configureModuleMeta(fetcher, referrer) {
@@ -92,44 +98,34 @@ function configureModuleMeta(fetcher, referrer) {
 
 
 function resolveMetaModule(fetcher) {
-  var context = fetcher.context;
+  const context = fetcher.context;
+  const controllers = context.controllers;
 
-  return function(moduleMeta) {
+  return function(mod) {
     return context.services.resolve
-      .runAsync(moduleMeta)
+      .runAsync(mod)
       .then(configureModuleId)
-      .then(function(moduleMeta) {
-        return (
-          fetcher.context.controllers.registry.hasModule(moduleMeta.id) ? moduleMeta :
-          moduleMeta.state ? fetcher.context.controllers.registry.setModule(moduleMeta) :
-          fetcher.context.controllers.registry.setModule(moduleMeta.withState(Module.State.RESOLVE))
-        );
-      });
+      .then((mod) => (
+        controllers.registry.hasModule(mod.id) ? mod :
+        mod.state ? controllers.registry.setModule(mod) :
+        controllers.registry.setModule(mod.withState(Module.State.RESOLVE))
+      ));
   };
 }
 
 
-function runFetchPipeline(fetcher, deep) {
-  return function runFetchPipelineDelegate(moduleMeta) {
-    return deep === false ?
-      fetchPipeline(fetcher, moduleMeta) :
-      fetchPipeline(fetcher, moduleMeta).then(fetchDependencies(fetcher));
-  };
-}
-
-
-function configureModuleId(moduleMeta) {
+function configureModuleId(mod) {
   var result = {};
 
-  if (!moduleMeta.path && moduleMeta.url) {
-    result.path = moduleMeta.url && moduleMeta.url.href;
+  if (!mod.path && mod.url) {
+    result.path = mod.url && mod.url.href;
   }
 
-  if (!moduleMeta.hasOwnProperty("id") && moduleMeta.path) {
-    result.id = moduleMeta.path;
+  if (!mod.hasOwnProperty("id") && mod.path) {
+    result.id = mod.path;
   }
 
-  return moduleMeta.configure(result);
+  return mod.configure(result);
 }
 
 
@@ -153,59 +149,46 @@ function precompileService(context) {
 }
 
 
-function fetchDependencies(fetcher) {
-  return function fetchDependenciesDelegate(moduleMeta) {
-    var mod = fetcher.context.controllers.registry.getModule(moduleMeta.id);
-
-    if (!mod.deps.length) {
-      return Promise.resolve(moduleMeta);
-    }
-
-    return resolveNames(fetcher, mod.deps, mod)
-      .then(function(result) {
-        return Promise
-          .all(result.map(function(dependency) {
-            return getInProgress(fetcher, dependency) || runFetchPipeline(fetcher)(dependency);
-          }))
-          .then(function(dependencies) {
-            fetcher.context.controllers.registry.updateModule(mod.configure({ deps: dependencies }));
-            return moduleMeta;
-          });
-      });
-  };
-}
-
-
-function fetchPipeline(fetcher, moduleMeta) {
-  logger.info(moduleMeta.name, moduleMeta);
-  return getInProgress(fetcher, moduleMeta) || runPipeline(fetcher, moduleMeta).then(function() { return moduleMeta; });
-}
-
-
-function getInProgress(fetcher, moduleMeta) {
-  if (fetcher.inProgress.hasOwnProperty(moduleMeta.id)) {
-    return fetcher.inProgress[moduleMeta.id].then(function() { return moduleMeta; });
+function getInProgress(fetcher, mod) {
+  if (fetcher.inProgress.hasOwnProperty(mod.id)) {
+    return fetcher.inProgress[mod.id].then(() => mod);
   }
 
-  if (fetcher.context.controllers.registry.hasModule(moduleMeta.id)) {
-    var state = fetcher.context.controllers.registry.getModuleState(moduleMeta.id);
+  if (fetcher.context.controllers.registry.hasModule(mod.id)) {
+    var state = fetcher.context.controllers.registry.getModuleState(mod.id);
 
     if (state !== Module.State.RESOLVE) {
-      return Promise.resolve(moduleMeta);
+      return Promise.resolve(mod);
     }
   }
 }
 
 
-function runPipeline(fetcher, moduleMeta) {
+function getIfReady(fetcher, mod) {
+  var state = fetcher.context.controllers.registry.getModuleState(mod.id);
+
+  if (state === Module.State.LOADED || state === Module.State.READY) {
+    return Promise.resolve(mod);
+  }
+}
+
+
+function runPipeline(fetcher, mod, services) {
+  logger.info(mod.name, mod);
+
   function deleteInProgress() {
-    delete fetcher.inProgress[moduleMeta.id];
+    delete fetcher.inProgress[mod.id];
   };
 
-  var inProgress = fetcher.pipeline.runAsync(moduleMeta);
+  const inProgress = services.reduce((deferred, service) => deferred.then(service), Promise.resolve(mod));
   inProgress.then(deleteInProgress, deleteInProgress);
-  fetcher.inProgress[moduleMeta.id] = inProgress;
-  return fetcher.inProgress[moduleMeta.id];
+  return (fetcher.inProgress[mod.id] = inProgress);
+}
+
+
+function buildResult(fetcher, items, modules) {
+  const getModule = (mod) => fetcher.context.controllers.registry.getModule(mod.id);
+  return Array.isArray(items) ? modules.map(getModule) : getModule(modules[0]);
 }
 
 

--- a/src/controllers/loader.js
+++ b/src/controllers/loader.js
@@ -33,7 +33,7 @@ inherit.base(Loader).extends(Controller);
  *
  * @returns {Promise} - Promise that will resolve to a Module instance
  */
-Loader.prototype.fromName = function fromName(names, referrer) {
+Loader.prototype.loadNames = Loader.prototype.load = function(names, referrer) {
   return (
     types.isArray(names) ?
     Promise.all(names.map((name) => this._loadName(name, referrer))) :
@@ -41,11 +41,8 @@ Loader.prototype.fromName = function fromName(names, referrer) {
   );
 };
 
-// same thing.
-Loader.prototype.load = Loader.prototype.fromName;
 
-
-Loader.prototype.fromSource = function fromSource(source, referrer) {
+Loader.prototype.loadSource = function fromSource(source, referrer) {
   if (!source) {
     return Promise.reject("Must provide a string source to load");
   }
@@ -61,7 +58,7 @@ Loader.prototype._loadName = function(name, referrer) {
   }
 
   const controllers = this.context.controllers;
-  return controllers.fetcher.fetch(name, referrer).then((mod) => controllers.builder.build(mod.id));
+  return controllers.fetcher.loadNames(name, referrer).then((mod) => controllers.builder.build(mod.id));
 };
 
 

--- a/src/file.js
+++ b/src/file.js
@@ -1,0 +1,35 @@
+var types = require("dis-isa");
+var utils = require("belty");
+
+function File(options) {
+  if (!(this instanceof File)) {
+    return new File(options);
+  }
+
+  return (
+    options instanceof File ?
+    utils.assign(this, options) :
+    utils.assign(this, configureFile(options))
+  );
+}
+
+function configureFile(file) {
+  if (!file) {
+    throw new TypeError("Must provide a valid input. String, Array<String>, { src: Array<String> }, { content: String | Buffer }");
+  }
+
+  if (types.isString(file) || types.isArray(file)) {
+    return { names: file };
+  }
+  else if (types.isArray(file.src) && file.src.length) {
+    return { names: file.src };
+  }
+  else if (types.isString(file.contents) || types.isBuffer(file.contents)) {
+    return { contents: file.contents.toString(), path: file.path };
+  }
+  else if (types.isString(file.source) || types.isBuffer(file.source)) {
+    return { contents: file.source.toString(), path: file.path };
+  }
+};
+
+module.exports = File;

--- a/src/module.js
+++ b/src/module.js
@@ -119,8 +119,8 @@ function Module(options) {
     };
   }
 
-  if (!types.isString(options.name)) {
-    throw new TypeError("Must provide a name, which is used by the resolver to resolve the path for the resource");
+  if (!types.isString(options.name) && !types.isString(options.source)) {
+    throw new TypeError("Must provide a name or source for the module");
   }
 
   this.deps = options.deps ? options.deps.slice(0) : [];

--- a/src/services/resolve.js
+++ b/src/services/resolve.js
@@ -14,7 +14,7 @@ inherit.base(Resolve).extends(Service);
 
 
 Resolve.prototype.canProcess = function(moduleMeta) {
-  return !moduleMeta.hasOwnProperty("path");
+  return moduleMeta.hasOwnProperty("name") && !moduleMeta.hasOwnProperty("path");
 };
 
 

--- a/test/spec/fetch.js
+++ b/test/spec/fetch.js
@@ -29,7 +29,7 @@ describe("Fetch Test Suite", function() {
     describe("and the module source is a hello world", function() {
       var result = null;
       beforeEach(function() {
-        return loader.fetchFromSource("console.log('hello world')").then(mod => result = mod);
+        return loader.fetch({ source: "console.log('hello world')" }).then(mod => result = mod);
       });
 
       it("then the module source has the expected data", function() {
@@ -44,7 +44,7 @@ describe("Fetch Test Suite", function() {
     describe("and the module source has one depdnency", function() {
       var result = null;
       beforeEach(function() {
-        return loader.fetchFromSource("require('path');console.log('hello world')").then(mod => result = mod);
+        return loader.fetch({ source: "require('path');console.log('hello world')" }).then(mod => result = mod);
       });
 
       it("then the module source has the expected data", function() {

--- a/test/spec/fetch.js
+++ b/test/spec/fetch.js
@@ -5,334 +5,388 @@ import Bitloader from "../../src/bit-loader";
 import Module from "../../src/module";
 
 describe("Fetch Test Suite", function() {
-  var loader, fetchStub, resolveStub, transformStub, dependencyStub, precompileStub;
-  var nameLikeData, resolveLikeData, fetchLikeData, transformLikeData, dependencyLikeData, precompileLikeData;
-  var nameDep1Data, resolveDep1Data, fetchDep1Data, transformDep1Data, dependencyDep1Data;
-  var nameCommonData, resolveCommonData, fetchCommonData, transformCommonData, dependencyCommonData;
-
-  beforeEach(function() {
-    nameLikeData = {name: "like"};
-    resolveLikeData = {path: "this is the real path to like/like-name", id: "like-id"};
-    fetchLikeData = {source: "source content"};
-    transformLikeData = {source: "transformed source"};
-    dependencyLikeData = {deps: ["dep1", "common-dep"]};
-    precompileLikeData = {source: "precompiled source"};
-
-
-    nameDep1Data = {name: "dep1"};
-    resolveDep1Data = {path: "real path to dep1", id: "dep1-id"};
-    fetchDep1Data = {source: "dep1 source"};
-    transformDep1Data = {source: "changed dep1 source"};
-    dependencyDep1Data = {deps: ["common-dep"]};
-
-    nameCommonData = {name: "common-dep"};
-    resolveCommonData = {path: "path to common-dep dependency", id: "common-id"};
-    fetchCommonData = {source: "source for common-dep"};
-    transformCommonData = {source: "transformed source for common-data"};
-    dependencyCommonData = {deps: []};
-
-    resolveStub = sinon.stub();
-    resolveStub
-      .withArgs(sinon.match(nameLikeData))
-      .returns(resolveLikeData);
-    resolveStub
-      .withArgs(sinon.match(nameDep1Data))
-      .returns(resolveDep1Data);
-    resolveStub
-      .withArgs(sinon.match(nameCommonData))
-      .returns(resolveCommonData);
-
-    fetchStub = sinon.stub();
-    fetchStub
-      .withArgs(sinon.match(nameLikeData))
-      .returns(fetchLikeData);
-    fetchStub
-      .withArgs(sinon.match(nameDep1Data))
-      .returns(fetchDep1Data);
-    fetchStub
-      .withArgs(sinon.match(nameCommonData))
-      .returns(fetchCommonData);
-
-    transformStub = sinon.stub();
-    transformStub
-      .withArgs(sinon.match(nameLikeData))
-      .returns(transformLikeData);
-    transformStub
-      .withArgs(sinon.match(nameDep1Data))
-      .returns(transformDep1Data);
-    transformStub
-      .withArgs(sinon.match(nameCommonData))
-      .returns(transformCommonData);
-
-    dependencyStub = sinon.stub();
-    dependencyStub
-      .withArgs(sinon.match(nameLikeData))
-      .returns(dependencyLikeData);
-    dependencyStub
-      .withArgs(sinon.match(nameDep1Data))
-      .returns(dependencyDep1Data);
-    dependencyStub
-      .withArgs(sinon.match(nameCommonData))
-      .returns(dependencyCommonData);
-
-    precompileStub = sinon.stub();
-    precompileStub
-      .withArgs(sinon.match(transformLikeData))
-      .returns(precompileLikeData);
-
-    loader = new Bitloader({
-      resolve: resolveStub,
-      fetch: fetchStub,
-      transform: transformStub,
-      dependency: dependencyStub,
-      precompile: precompileStub
-    });
-  });
-
-
-  describe("When fetching a module called `like`", function() {
-    var result;
+  describe("When loading modules from source", function() {
+    var loader, fetchStub, resolveStub, transformStub, dependencyStub, precompileStub;
 
     beforeEach(function() {
-      return loader.controllers.fetcher.fetch("like").then(function(r) {
-        result = r;
+      fetchStub = sinon.stub();
+      resolveStub = sinon.stub();
+      transformStub = sinon.stub();
+      dependencyStub = sinon.stub();
+      precompileStub = sinon.stub();
+
+      dependencyStub.returns({ deps: ["test that path"]});
+
+      loader = new Bitloader({
+        resolve: resolveStub,
+        fetch: fetchStub,
+        transform: transformStub,
+        dependency: dependencyStub,
+        precompile: precompileStub
       });
     });
 
-    it("then `resolve` is called with `like` name data", function() {
-      sinon.assert.calledWith(resolveStub, sinon.match(nameLikeData));
-    });
-
-    it("then `resolve` is called with `dep1` name data", function() {
-      sinon.assert.calledWith(resolveStub, sinon.match(nameDep1Data));
-    });
-
-    it("then `resolve` is called with `common-dep` name data", function() {
-      sinon.assert.calledWith(resolveStub, sinon.match(nameCommonData));
-    });
-
-    it("then `fetch` is called with `like` resolve data", function() {
-      sinon.assert.calledWith(fetchStub, sinon.match(resolveLikeData));
-    });
-
-    it("then `fetch` is called with `dep1` resolve data", function() {
-      sinon.assert.calledWith(fetchStub, sinon.match(resolveDep1Data));
-    });
-
-    it("then `fetch` is called with `common-dep` resolve data", function() {
-      sinon.assert.calledWith(fetchStub, sinon.match(resolveCommonData));
-    });
-
-    it("then `transform` is called with `like` fetch data", function() {
-      sinon.assert.calledWith(transformStub, sinon.match(fetchLikeData));
-    });
-
-    it("then `transform` is called with `dep1` fetch data", function() {
-      sinon.assert.calledWith(transformStub, sinon.match(fetchDep1Data));
-    });
-
-    it("then `transform` is called with `common-dep` fetch data", function() {
-      sinon.assert.calledWith(transformStub, sinon.match(fetchCommonData));
-    });
-
-    it("then `dependency` is called with `like` tranfom data", function() {
-      sinon.assert.calledWith(dependencyStub, sinon.match(transformLikeData));
-    });
-
-    it("then `dependency` is called with `dep1` tranfom data", function() {
-      sinon.assert.calledWith(dependencyStub, sinon.match(transformDep1Data));
-    });
-
-    it("then `dependency` is called with `common-dep` tranfom data", function() {
-      sinon.assert.calledWith(dependencyStub, sinon.match(transformCommonData));
-    });
-
-    it("then `precompile` is called with `like` transform data", function() {
-      sinon.assert.calledWith(precompileStub, sinon.match(transformLikeData));
-    });
-
-    it("then `precompile` is called with `dep1` transform data", function() {
-      sinon.assert.calledWith(precompileStub, sinon.match(transformDep1Data));
-    });
-
-    it("then `precompile` is called with `common-dep` transform data", function() {
-      sinon.assert.calledWith(precompileStub, sinon.match(transformCommonData));
-    });
-
-    it("then the module contains the expected referrer", function() {
-      expect(result.referrer).to.eql({});
-    });
-
-    it("then the module has two dependencies", function() {
-      expect(result.deps).to.have.lengthOf(2)
-    });
-
-    it("then one of the dependencies is dep1", function() {
-      expect(result.deps[0]).to.deep.include({ name: "dep1" });
-    });
-
-    it("then one of the dependencies is common-dep", function() {
-      expect(result.deps[1]).to.deep.include({ name: "common-dep" });
-    });
-
-    it("then the result will have all the aggregated data", function() {
-      expect(result).to.include({
-        directory: "this is the real path to like/",
-        filename: "like-name",
-        id: "like-id",
-        name: "like",
-        path: "this is the real path to like/like-name",
-        state: "loaded",
-        source: "precompiled source",
-        type: "UNKNOWN"
-      });
-    });
-
-    describe("and reading the loaded `like` module", function() {
-      var loadedModule;
-
+    describe("and the module source is a hello world", function() {
+      var result = null;
       beforeEach(function() {
-        loadedModule = loader.getModule("like-id");
+        return loader.fetchFromSource("console.log('hello world')").then(mod => result = mod);
       });
 
-      it("the module has two dependencies", function() {
-        expect(loadedModule.deps).to.have.lengthOf(2);
+      it("then the module source has the expected data", function() {
+        expect(result.source).to.equal("console.log('hello world')");
       });
 
-      it("then the first dependency is dep1", function() {
-        expect(loadedModule.deps[0].id).to.equal("dep1-id");
-      });
-
-      it("then the first dependency has the correct referrer", function() {
-        expect(loadedModule.deps[0].referrer).to.eql({
-          id: "like-id",
-          name: "like",
-          path: "this is the real path to like/like-name",
-          filename: "like-name"
-        });
-      });
-
-      it("then the second dependency is common-dep", function() {
-        expect(loadedModule.deps[1].id).to.equal("common-id");
-      });
-
-      it("then the second dependency has the correct referrer", function() {
-        expect(loadedModule.deps[1].referrer).to.eql({
-          id: "like-id",
-          name: "like",
-          path: "this is the real path to like/like-name",
-          filename: "like-name"
-        });
-      });
-
-      it("then the source is the precompiled source", function() {
-        expect(loadedModule.source).to.equal(precompileLikeData.source);
+      it("then the module has one dependencies", function() {
+        expect(result.deps).to.have.lengthOf(1);
       });
     });
 
-    describe("and reading the loaded `dep1` module", function() {
-      var loadedModule;
-
+    describe("and the module source has one depdnency", function() {
+      var result = null;
       beforeEach(function() {
-        loadedModule = loader.getModule("dep1-id");
+        return loader.fetchFromSource("require('path');console.log('hello world')").then(mod => result = mod);
       });
 
-      it("the module has one dependency", function() {
-        expect(loadedModule.deps).to.have.lengthOf(1);
+      it("then the module source has the expected data", function() {
+        expect(result.source).to.equal("require('path');console.log('hello world')");
       });
 
-      it("then the first dependency is common-dep", function() {
-        expect(loadedModule.deps[0].id).to.equal("common-id");
-      });
-
-      it("then the dependency has the correct referrer", function() {
-        expect(loadedModule.deps[0].referrer).to.eql({
-          id: "dep1-id",
-          name: "dep1",
-          path: "real path to dep1",
-          filename: ""
-        });
-      });
-
-      it("then the source is the transformed source", function() {
-        expect(loadedModule.source).to.equal(transformDep1Data.source);
-      });
-    });
-
-    describe("and reading the loaded `common-dep` module", function() {
-      var loadedModule;
-
-      beforeEach(function() {
-        loadedModule = loader.getModule("common-id");
-      });
-
-      it("the module has no dependencies", function() {
-        expect(loadedModule.deps).to.be.empty;
-      });
-
-      it("then the common-dep has the correct referrer", function() {
-        expect(loadedModule.referrer).to.eql({
-          id: "like-id",
-          name: "like",
-          path: "this is the real path to like/like-name",
-          filename: "like-name"
-        });
-      });
-
-      it("then the source is the transformed source", function() {
-        expect(loadedModule.source).to.equal(transformCommonData.source);
+      it("then the module has one dependencies", function() {
+        expect(result.deps).to.have.lengthOf(1);
       });
     });
   });
 
-  describe("When registering a preresolve plugin to exclude modules", function() {
-    var excludeName, result;
+  describe("When loading modules by name", function() {
+    var loader, fetchStub, resolveStub, transformStub, dependencyStub, precompileStub;
+    var nameLikeData, resolveLikeData, fetchLikeData, transformLikeData, dependencyLikeData, precompileLikeData;
+    var nameDep1Data, resolveDep1Data, fetchDep1Data, transformDep1Data, dependencyDep1Data;
+    var nameCommonData, resolveCommonData, fetchCommonData, transformCommonData, dependencyCommonData;
 
     beforeEach(function() {
-      excludeName = chance().string();
+      nameLikeData = {name: "like"};
+      resolveLikeData = {path: "this is the real path to like/like-name", id: "like-id"};
+      fetchLikeData = {source: "source content"};
+      transformLikeData = {source: "transformed source"};
+      dependencyLikeData = {deps: ["dep1", "common-dep"]};
+      precompileLikeData = {source: "precompiled source"};
 
-      return loader
-        .plugin({
-          preresolve: function(data) {
-            if (data.name === excludeName) {
-              return {
-                id: data.name,
-                path: null,
-                source: "",
-                state: "loaded"
-              };
-            }
-          }
-        })
-        .controllers.fetcher
-        .fetch(excludeName)
-        .then(function(r) {
+
+      nameDep1Data = {name: "dep1"};
+      resolveDep1Data = {path: "real path to dep1", id: "dep1-id"};
+      fetchDep1Data = {source: "dep1 source"};
+      transformDep1Data = {source: "changed dep1 source"};
+      dependencyDep1Data = {deps: ["common-dep"]};
+
+      nameCommonData = {name: "common-dep"};
+      resolveCommonData = {path: "path to common-dep dependency", id: "common-id"};
+      fetchCommonData = {source: "source for common-dep"};
+      transformCommonData = {source: "transformed source for common-data"};
+      dependencyCommonData = {deps: []};
+
+      resolveStub = sinon.stub();
+      resolveStub
+        .withArgs(sinon.match(nameLikeData))
+        .returns(resolveLikeData);
+      resolveStub
+        .withArgs(sinon.match(nameDep1Data))
+        .returns(resolveDep1Data);
+      resolveStub
+        .withArgs(sinon.match(nameCommonData))
+        .returns(resolveCommonData);
+
+      fetchStub = sinon.stub();
+      fetchStub
+        .withArgs(sinon.match(nameLikeData))
+        .returns(fetchLikeData);
+      fetchStub
+        .withArgs(sinon.match(nameDep1Data))
+        .returns(fetchDep1Data);
+      fetchStub
+        .withArgs(sinon.match(nameCommonData))
+        .returns(fetchCommonData);
+
+      transformStub = sinon.stub();
+      transformStub
+        .withArgs(sinon.match(nameLikeData))
+        .returns(transformLikeData);
+      transformStub
+        .withArgs(sinon.match(nameDep1Data))
+        .returns(transformDep1Data);
+      transformStub
+        .withArgs(sinon.match(nameCommonData))
+        .returns(transformCommonData);
+
+      dependencyStub = sinon.stub();
+      dependencyStub
+        .withArgs(sinon.match(nameLikeData))
+        .returns(dependencyLikeData);
+      dependencyStub
+        .withArgs(sinon.match(nameDep1Data))
+        .returns(dependencyDep1Data);
+      dependencyStub
+        .withArgs(sinon.match(nameCommonData))
+        .returns(dependencyCommonData);
+
+      precompileStub = sinon.stub();
+      precompileStub
+        .withArgs(sinon.match(transformLikeData))
+        .returns(precompileLikeData);
+
+      loader = new Bitloader({
+        resolve: resolveStub,
+        fetch: fetchStub,
+        transform: transformStub,
+        dependency: dependencyStub,
+        precompile: precompileStub
+      });
+    });
+
+
+    describe("When fetching a module called `like`", function() {
+      var result;
+
+      beforeEach(function() {
+        return loader.controllers.fetcher.fetch("like").then(function(r) {
           result = r;
         });
+      });
+
+      it("then `resolve` is called with `like` name data", function() {
+        sinon.assert.calledWith(resolveStub, sinon.match(nameLikeData));
+      });
+
+      it("then `resolve` is called with `dep1` name data", function() {
+        sinon.assert.calledWith(resolveStub, sinon.match(nameDep1Data));
+      });
+
+      it("then `resolve` is called with `common-dep` name data", function() {
+        sinon.assert.calledWith(resolveStub, sinon.match(nameCommonData));
+      });
+
+      it("then `fetch` is called with `like` resolve data", function() {
+        sinon.assert.calledWith(fetchStub, sinon.match(resolveLikeData));
+      });
+
+      it("then `fetch` is called with `dep1` resolve data", function() {
+        sinon.assert.calledWith(fetchStub, sinon.match(resolveDep1Data));
+      });
+
+      it("then `fetch` is called with `common-dep` resolve data", function() {
+        sinon.assert.calledWith(fetchStub, sinon.match(resolveCommonData));
+      });
+
+      it("then `transform` is called with `like` fetch data", function() {
+        sinon.assert.calledWith(transformStub, sinon.match(fetchLikeData));
+      });
+
+      it("then `transform` is called with `dep1` fetch data", function() {
+        sinon.assert.calledWith(transformStub, sinon.match(fetchDep1Data));
+      });
+
+      it("then `transform` is called with `common-dep` fetch data", function() {
+        sinon.assert.calledWith(transformStub, sinon.match(fetchCommonData));
+      });
+
+      it("then `dependency` is called with `like` tranfom data", function() {
+        sinon.assert.calledWith(dependencyStub, sinon.match(transformLikeData));
+      });
+
+      it("then `dependency` is called with `dep1` tranfom data", function() {
+        sinon.assert.calledWith(dependencyStub, sinon.match(transformDep1Data));
+      });
+
+      it("then `dependency` is called with `common-dep` tranfom data", function() {
+        sinon.assert.calledWith(dependencyStub, sinon.match(transformCommonData));
+      });
+
+      it("then `precompile` is called with `like` transform data", function() {
+        sinon.assert.calledWith(precompileStub, sinon.match(transformLikeData));
+      });
+
+      it("then `precompile` is called with `dep1` transform data", function() {
+        sinon.assert.calledWith(precompileStub, sinon.match(transformDep1Data));
+      });
+
+      it("then `precompile` is called with `common-dep` transform data", function() {
+        sinon.assert.calledWith(precompileStub, sinon.match(transformCommonData));
+      });
+
+      it("then the module contains the expected referrer", function() {
+        expect(result.referrer).to.eql({});
+      });
+
+      it("then the module has two dependencies", function() {
+        expect(result.deps).to.have.lengthOf(2)
+      });
+
+      it("then one of the dependencies is dep1", function() {
+        expect(result.deps[0]).to.deep.include({ name: "dep1" });
+      });
+
+      it("then one of the dependencies is common-dep", function() {
+        expect(result.deps[1]).to.deep.include({ name: "common-dep" });
+      });
+
+      it("then the result will have all the aggregated data", function() {
+        expect(result).to.include({
+          directory: "this is the real path to like/",
+          filename: "like-name",
+          id: "like-id",
+          name: "like",
+          path: "this is the real path to like/like-name",
+          state: "loaded",
+          source: "precompiled source",
+          type: "UNKNOWN"
+        });
+      });
+
+      describe("and reading the loaded `like` module", function() {
+        var loadedModule;
+
+        beforeEach(function() {
+          loadedModule = loader.getModule("like-id");
+        });
+
+        it("the module has two dependencies", function() {
+          expect(loadedModule.deps).to.have.lengthOf(2);
+        });
+
+        it("then the first dependency is dep1", function() {
+          expect(loadedModule.deps[0].id).to.equal("dep1-id");
+        });
+
+        it("then the first dependency has the correct referrer", function() {
+          expect(loadedModule.deps[0].referrer).to.eql({
+            id: "like-id",
+            name: "like",
+            path: "this is the real path to like/like-name",
+            filename: "like-name"
+          });
+        });
+
+        it("then the second dependency is common-dep", function() {
+          expect(loadedModule.deps[1].id).to.equal("common-id");
+        });
+
+        it("then the second dependency has the correct referrer", function() {
+          expect(loadedModule.deps[1].referrer).to.eql({
+            id: "like-id",
+            name: "like",
+            path: "this is the real path to like/like-name",
+            filename: "like-name"
+          });
+        });
+
+        it("then the source is the precompiled source", function() {
+          expect(loadedModule.source).to.equal(precompileLikeData.source);
+        });
+      });
+
+      describe("and reading the loaded `dep1` module", function() {
+        var loadedModule;
+
+        beforeEach(function() {
+          loadedModule = loader.getModule("dep1-id");
+        });
+
+        it("the module has one dependency", function() {
+          expect(loadedModule.deps).to.have.lengthOf(1);
+        });
+
+        it("then the first dependency is common-dep", function() {
+          expect(loadedModule.deps[0].id).to.equal("common-id");
+        });
+
+        it("then the dependency has the correct referrer", function() {
+          expect(loadedModule.deps[0].referrer).to.eql({
+            id: "dep1-id",
+            name: "dep1",
+            path: "real path to dep1",
+            filename: ""
+          });
+        });
+
+        it("then the source is the transformed source", function() {
+          expect(loadedModule.source).to.equal(transformDep1Data.source);
+        });
+      });
+
+      describe("and reading the loaded `common-dep` module", function() {
+        var loadedModule;
+
+        beforeEach(function() {
+          loadedModule = loader.getModule("common-id");
+        });
+
+        it("the module has no dependencies", function() {
+          expect(loadedModule.deps).to.be.empty;
+        });
+
+        it("then the common-dep has the correct referrer", function() {
+          expect(loadedModule.referrer).to.eql({
+            id: "like-id",
+            name: "like",
+            path: "this is the real path to like/like-name",
+            filename: "like-name"
+          });
+        });
+
+        it("then the source is the transformed source", function() {
+          expect(loadedModule.source).to.equal(transformCommonData.source);
+        });
+      });
     });
 
-    it("then resolve provider is not called", function() {
-      sinon.assert.notCalled(resolveStub);
-    });
+    describe("When registering a preresolve plugin to exclude modules", function() {
+      var excludeName, result;
 
-    it("then fetch provider is not called", function() {
-      sinon.assert.notCalled(fetchStub);
-    });
+      beforeEach(function() {
+        excludeName = chance().string();
 
-    it("then module meta path is `null`", function() {
-      expect(result.path).to.equal(null);
-    });
+        return loader
+          .plugin({
+            preresolve: function(data) {
+              if (data.name === excludeName) {
+                return {
+                  id: data.name,
+                  path: null,
+                  source: "",
+                  state: "loaded"
+                };
+              }
+            }
+          })
+          .controllers.fetcher
+          .fetch(excludeName)
+          .then(function(r) {
+            result = r;
+          });
+      });
 
-    it("then module meta name is properly set", function() {
-      expect(result.name).to.equal(excludeName);
-    });
+      it("then resolve provider is not called", function() {
+        sinon.assert.notCalled(resolveStub);
+      });
 
-    it("then module meta id is properly set", function() {
-      expect(result.id).to.equal(excludeName);
-    });
+      it("then fetch provider is not called", function() {
+        sinon.assert.notCalled(fetchStub);
+      });
 
-    it("then module meta source is properly set", function() {
-      expect(result.source).to.equal("");
+      it("then module meta path is `null`", function() {
+        expect(result.path).to.equal(null);
+      });
+
+      it("then module meta name is properly set", function() {
+        expect(result.name).to.equal(excludeName);
+      });
+
+      it("then module meta id is properly set", function() {
+        expect(result.id).to.equal(excludeName);
+      });
+
+      it("then module meta source is properly set", function() {
+        expect(result.source).to.equal("");
+      });
     });
   });
 });

--- a/test/spec/module.js
+++ b/test/spec/module.js
@@ -12,7 +12,7 @@ describe("Module Test Suite", function() {
 
     describe("and the module meta is empty - no name", function() {
       it("then an exception is thrown because a name must be provided", function() {
-        expect(act).to.throw(TypeError, "Must provide a name, which is used by the resolver to resolve the path for the resource");
+        expect(act).to.throw(TypeError, "Must provide a name or source for the module");
       });
     });
 


### PR DESCRIPTION
Adding the ability to load a module from loading its source and feeding that through the pipeline.  This PR also include a major refactor to make the module tree building logic more obvious as far as what it is doing.