### PR TITLE
moved post service hooks to execute after the default provider

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -67,8 +67,8 @@ Service.prototype.runAsync = function(moduleMeta) {
   return Promise.resolve(moduleMeta)
     .then(runPipelineAsync(this.pre))
     .then(runPipelineAsync(this))
-    .then(runPipelineAsync(this.post))
     .then(runProviderAsync(this))
+    .then(runPipelineAsync(this.post))
     .then(logIt(this));
 };
 
@@ -81,8 +81,8 @@ Service.prototype.runSync = function(moduleMeta) {
   return [
     runPipelineSync(this.pre),
     runPipelineSync(this),
-    runPipelineSync(this.post),
     runProviderSync(this),
+    runPipelineSync(this.post),
     logIt(this)
   ].reduce(function(data, handler) {
     return handler(data);


### PR DESCRIPTION
it is more expected behavior to have the post hook to run after the default the provider in order to really get the result after the service has had a chance to process modules with all registered plugins and providers.

for example, if the default provider for processing dependencies is called and it actually parses out dependencies, post hooks wont get notified with the dependencies because post would be executed after registered plugin but before the default provider. So post hooks wont get the dependencies parsed by the default provider.