### PR TITLE
Merged dependency and precompile

### DIFF
--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -20,7 +20,7 @@ inherit.base(Fetcher).extends(Controller);
 
 Fetcher.prototype.fetch = function(data, referrer, deep) {
   const file = new File(data);
-  const services = [fetchService, transformService, dependencyService, precompileService];
+  const services = [fetchService, transformService, dependencyService];
   const filePath = file.content && types.isArray(file.path) ? file.path[0] : file.path;
   const fetchFile = file.content ? { id: "@anonymous-" + id++, source: file.content, path: filePath } : filePath;
 
@@ -152,12 +152,7 @@ function transformService(context) {
 
 
 function dependencyService(context) {
-  return helpers.serviceRunner(context, Module.State.TRANSFORM, Module.State.DEPENDENCY, context.services.dependency);
-}
-
-
-function precompileService(context) {
-  return helpers.serviceRunner(context, Module.State.DEPENDENCY, Module.State.LOADED, context.services.precompile);
+  return helpers.serviceRunner(context, Module.State.TRANSFORM, Module.State.LOADED, context.services.dependency);
 }
 
 

--- a/src/module.js
+++ b/src/module.js
@@ -21,11 +21,10 @@ var Type = {
  * stage. The different states are REGISTERED, LOADED, READY.
  *
  * <pre>
- * REGISTERED has four stages before a module can be LOADED.
+ * REGISTERED has three stages before a module can be LOADED.
  *  1. RESOLVE.
  *  2. FETCH.
  *  3. TRANSFORM.
- *  4. DEPENDENCY.
  *
  * LOADED has two stages before a module can be READY.
  *  1. COMPILE.
@@ -61,12 +60,6 @@ var State = {
    * @description When the module is going through the transform pipeline
    */
   TRANSFORM: "transform",
-
-  /**
-   * @type { string }
-   * @description When the moule is getting all the dependencies resolved
-   */
-  DEPENDENCY: "dependency",
 
   /**
    * @type { string }

--- a/test/spec/bit-loader.js
+++ b/test/spec/bit-loader.js
@@ -42,7 +42,7 @@ describe("Bitloader Test Suite", function() {
   });
 
   describe("When creating a new instance of Bitloader with a plugin with handlers for `fetch`, `transform`, `dependency`, and `compile`", function() {
-    var defaultResolveStub, defaultFetchStub, defaultCompileStub, resolveStub, fetchStub, transformStub, dependencyStub, precompileStub, compileStub;
+    var defaultResolveStub, defaultFetchStub, defaultCompileStub, resolveStub, fetchStub, transformStub, dependencyStub, postdependecyStub, precompileStub, compileStub;
 
     beforeEach(function() {
       defaultResolveStub = sinon.stub();
@@ -52,7 +52,8 @@ describe("Bitloader Test Suite", function() {
       fetchStub          = sinon.spy(function() { return { source: "var t = 'some source'; module.exports = t;" }; });
       transformStub      = sinon.spy(function() { return { source: "var t = 'transformed source'; module.exports = t;" }; });
       dependencyStub     = sinon.spy(function() { return { deps: [] }; });
-      precompileStub     = sinon.spy(function() { return { source: "module.exports = 'final vvvvalue';" }; });
+      postdependecyStub  = sinon.spy(function() { return { source: "module.exports = 'final vvvvalue';" }; });
+      precompileStub     = sinon.spy(function() { return { source: "should never be called" }; });
       compileStub        = sinon.spy(function() { return { exports: "compiled source" }; });
 
       bitloader = new Bitloader({
@@ -61,12 +62,13 @@ describe("Bitloader Test Suite", function() {
           compile : defaultCompileStub
         })
         .plugin({
-          resolve    : resolveStub,
-          fetch      : fetchStub,
-          transform  : transformStub,
-          dependency : dependencyStub,
-          precompile : precompileStub,
-          compile    : compileStub
+          resolve: resolveStub,
+          fetch: fetchStub,
+          transform: transformStub,
+          dependency: dependencyStub,
+          postdependency: postdependecyStub,
+          precompile: precompileStub,
+          compile: compileStub
         });
     });
 
@@ -115,12 +117,16 @@ describe("Bitloader Test Suite", function() {
         sinon.assert.calledOnce(dependencyStub);
       });
 
-      it("then `precompile` plugin is called once", function() {
-        sinon.assert.calledOnce(precompileStub);
+      it("then `postdependency` plugin is called once", function() {
+        sinon.assert.calledOnce(postdependecyStub);
       });
 
-      it("then `precompile` plugin is called once", function() {
-        sinon.assert.calledWith(precompileStub, sinon.match({deps: []}));
+      it("then `postdependency` plugin is called once", function() {
+        sinon.assert.calledWith(postdependecyStub, sinon.match({deps: []}));
+      });
+
+      it("then `precompile` plugin is NOT called", function() {
+        sinon.assert.notCalled(precompileStub);
       });
 
       it("then `compile` plugin is NOT called", function() {

--- a/test/spec/fetch.js
+++ b/test/spec/fetch.js
@@ -129,9 +129,6 @@ describe("Fetch Test Suite", function() {
         .returns(dependencyCommonData);
 
       precompileStub = sinon.stub();
-      precompileStub
-        .withArgs(sinon.match(transformLikeData))
-        .returns(precompileLikeData);
 
       loader = new Bitloader({
         resolve: resolveStub,
@@ -232,16 +229,8 @@ describe("Fetch Test Suite", function() {
         sinon.assert.calledWith(dependencyStub, sinon.match(transformCommonData));
       });
 
-      it("then `precompile` is called with `like` transform data", function() {
-        sinon.assert.calledWith(precompileStub, sinon.match(transformLikeData));
-      });
-
-      it("then `precompile` is called with `dep1` transform data", function() {
-        sinon.assert.calledWith(precompileStub, sinon.match(transformDep1Data));
-      });
-
-      it("then `precompile` is called with `common-dep` transform data", function() {
-        sinon.assert.calledWith(precompileStub, sinon.match(transformCommonData));
+      it("then `precompile` is never called", function() {
+        sinon.assert.notCalled(precompileStub);
       });
 
       it("then the module contains the expected referrer", function() {
@@ -268,7 +257,7 @@ describe("Fetch Test Suite", function() {
           name: "like",
           path: "this is the real path to like/like-name",
           state: "loaded",
-          source: "precompiled source",
+          source: "transformed source",
           type: "UNKNOWN"
         });
       });
@@ -311,7 +300,7 @@ describe("Fetch Test Suite", function() {
         });
 
         it("then the source is the precompiled source", function() {
-          expect(loadedModule.source).to.equal(precompileLikeData.source);
+          expect(loadedModule.source).to.equal(transformLikeData.source);
         });
       });
 


### PR DESCRIPTION
to simplify the module processing workflow, i have merged the precompile and the dependency service. Now once the dependency service executes, the module becomes 'LOADED'.  The module state of 'DEPENDENCY' no longer exists.