### PR TITLE
adding temporary fix to make sure 9.2 release builds continue to work

### DIFF
--- a/src/controllers/fetcher.js
+++ b/src/controllers/fetcher.js
@@ -141,7 +141,7 @@ function configureServices(context, services) {
 
 
 function configureFiles(files) {
-  return [].concat(files).map(file => {
+  return [].concat(files && files.src ? files.src : files).map(file => {
     const source = types.isString(file) ? false : (file.source || file.content);
 
     return (


### PR DESCRIPTION
release 9.2.0 is not working due to a regression from reworking how files are processed as input in the fetch API. So this is a fix for that.