### PR TITLE
changed travis script to run the build and then tests to make we catc…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
 - '5'
+script:
+  - npm run build
+  - npm test
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
…h build failure even when we are not deploying

There have been failures in the past that have not been caught until deploy because the build step does not run in regular travis builds; only tests execute. So Im changing the travis script to build first, then run tests to make sure we get build failures when dealing with PRs.