### PR TITLE
migrating npm scripts to call pakit for building the bundle

### DIFF
--- a/.pakit.json
+++ b/.pakit.json
@@ -1,0 +1,4 @@
+{
+    "umd": "bitloader",
+    "builtins": false
+}

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "loader"
   ],
   "scripts": {
-    "prepublish": "grunt build",
-    "grunt:test": "grunt test",
-    "build": "grunt build",
-    "test": "mocha --require babel-register test/SpecRunner.js"
+    "prepublish": "npm run build",
+    "build": "pakit src/bit-loader.js --out dist/index.js",
+    "test": "npm run lint && mocha --require babel-register test/SpecRunner.js",
+    "lint": "eslint src/**/*.js test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,23 +3,16 @@
     "browser": true,
     "es6": true
   },
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
-  },
-  "ecmaFeatures": {
-    "modules": true
-  },
   "rules": {
     "curly": 2,
-    "no-console": 1,
-    "no-debugger": 1,
+    "no-console": 2,
+    "no-debugger": 2,
     "no-alert": 2,
     "no-use-before-define": 0,
     "no-underscore-dangle": 0,
     "no-multi-spaces": 0,
-    "no-unused-vars": 1,
-    "semi": 1,
+    "no-unused-vars": 2,
+    "semi": 2,
     "global-strict": 0,
     "wrap-iife": [2, "inside"],
     "quotes": [2, "double"],

--- a/test/spec/fetch.js
+++ b/test/spec/fetch.js
@@ -2,7 +2,6 @@ import chanceFactory from "chance";
 import { expect } from "chai";
 import sinon from "sinon";
 import Bitloader from "../../src/bit-loader";
-import Module from "../../src/module";
 
 const chance = chanceFactory();
 
@@ -91,7 +90,7 @@ describe("Fetch Test Suite", function() {
           it("then the module has one dependencies", function() {
             expect(result.deps).to.have.lengthOf(1);
           });
-        })
+        });
       });
   
       describe("and fetching two modules. One with source of 'hello world' and another with source 'second time'", function() {
@@ -254,7 +253,7 @@ describe("Fetch Test Suite", function() {
   });
 
   describe("When loading a module with a name and path", function() {
-    var loader, fetchStub, resolveStub, transformStub, dependencyStub, precompileStub;
+    var loader, fetchStub, resolveStub, transformStub, dependencyStub;
 
     beforeEach(function() {
       fetchStub = sinon.stub();
@@ -274,7 +273,7 @@ describe("Fetch Test Suite", function() {
 
     describe("and the module has name `test` and path `23`", function() {
       beforeEach(function() {
-        return loader.fetch([{ name: 'test', path: "23" }]);
+        return loader.fetch([{ name: "test", path: "23" }]);
       });
 
       it("then the resolve method is never called", function() {
@@ -285,7 +284,7 @@ describe("Fetch Test Suite", function() {
 
   describe("When loading modules by name", function() {
     var loader, fetchStub, resolveStub, transformStub, dependencyStub, precompileStub;
-    var nameLikeData, resolveLikeData, fetchLikeData, transformLikeData, dependencyLikeData, precompileLikeData;
+    var nameLikeData, resolveLikeData, fetchLikeData, transformLikeData, dependencyLikeData;
     var nameDep1Data, resolveDep1Data, fetchDep1Data, transformDep1Data, dependencyDep1Data;
     var nameCommonData, resolveCommonData, fetchCommonData, transformCommonData, dependencyCommonData;
 
@@ -295,8 +294,6 @@ describe("Fetch Test Suite", function() {
       fetchLikeData = {source: "source content"};
       transformLikeData = {source: "transformed source"};
       dependencyLikeData = {deps: ["dep1", "common-dep"]};
-      precompileLikeData = {source: "precompiled source"};
-
 
       nameDep1Data = {name: "dep1"};
       resolveDep1Data = {path: "real path to dep1", id: "dep1-id"};
@@ -464,7 +461,7 @@ describe("Fetch Test Suite", function() {
       });
 
       it("then the module has two dependencies", function() {
-        expect(result.deps).to.have.lengthOf(2)
+        expect(result.deps).to.have.lengthOf(2);
       });
 
       it("then one of the dependencies is dep1", function() {


### PR DESCRIPTION
migrating npm scripts to call pakit for building the bundle instead of the grunt script. Also added an npm script to run eslint before running tests. Fixed up eslint config files as well.

this is taking steps towards removing grunt